### PR TITLE
Show share link on mobile during waiting phase

### DIFF
--- a/src/apps/golf/components/GolfGame.module.css
+++ b/src/apps/golf/components/GolfGame.module.css
@@ -152,7 +152,8 @@
   flex: 1;
 }
 
-.gameHeaderShare {
+.gameHeaderShare,
+.gameHeaderShareWaiting {
   flex-shrink: 0;
 }
 

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -388,7 +388,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
             </div>
           </div>
           {currentGamePermalink && (
-            <div className={styles.gameHeaderShare}>
+            <div className={gameState.gamePhase === 'waiting' ? styles.gameHeaderShareWaiting : styles.gameHeaderShare}>
               <PermalinkDisplay
                 label="Share Game"
                 url={currentGamePermalink}


### PR DESCRIPTION
The game share link was hidden on mobile for all phases. During waiting this prevents inviting others. Swapped in a separate CSS class for the waiting phase so it stays visible when it matters.

Closes #212