### PR TITLE
Wire up Leave Room in golf frontend

### DIFF
--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -63,6 +63,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     handleCardClick,
     setRoomCode,
     leaveGame,
+    leaveRoom,
     dismissNewGameNotification,
     joinNewGame,
     permalinkJoinAttempt
@@ -344,6 +345,10 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
               </div>
             </div>
           )}
+
+          <button onClick={leaveRoom} className={styles.textLink}>
+            Leave Room
+          </button>
         </div>
 
         {notification && (

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -73,6 +73,7 @@ interface UseGolfGameReturn {
   setRoomCode: (code: string) => void
   clearGameState: () => void
   leaveGame: () => void
+  leaveRoom: () => void
 
   // Computed
   currentPlayer: Player | undefined
@@ -293,6 +294,21 @@ export const useGolfGame = ({
     setFinalScores(null)
     setSelectedCardIndex(null)
   }, [])
+
+  const leaveRoom = useCallback(() => {
+    if (roomState?.id) {
+      networkAdapterRef.current?.leaveRoom(roomState.id)
+    }
+    setRoomState(null)
+    setGameState(null)
+    setIsInRoom(false)
+    setIsInLobby(true)
+    setWinner(null)
+    setFinalScores(null)
+    setSelectedCardIndex(null)
+    setNewGameNotifications([])
+    navigate('/golf', { replace: true })
+  }, [roomState?.id, navigate])
 
   // Navigation helper functions
   const navigateToRoom = useCallback((roomId: string) => {
@@ -827,6 +843,7 @@ export const useGolfGame = ({
     setRoomCode,
     clearGameState,
     leaveGame,
+    leaveRoom,
 
     // Navigation helpers
     navigateToRoom,

--- a/src/plugins/golfNetworkPlugin.ts
+++ b/src/plugins/golfNetworkPlugin.ts
@@ -12,7 +12,7 @@ interface GolfMessage extends BaseNetworkMessage {
   type: 'authenticate' | 'authenticated' | 'createRoom' | 'joinRoom' | 'createGame' | 'joinGame' | 'roomJoined' | 'roomStateUpdate' | 'gameState' | 'error' |
         'gameStarted' | 'turnChanged' | 'playerKnocked' | 'gameEnded' | 'newGameStarted' |
         'startGame' | 'peekCard' | 'drawCard' | 'takeFromDiscard' |
-        'swapCard' | 'discardDrawn' | 'knock' | 'hideCards' | 'startNewGame' | 'leaveGame'
+        'swapCard' | 'discardDrawn' | 'knock' | 'hideCards' | 'startNewGame' | 'leaveGame' | 'leaveRoom'
   // Request fields
   roomId?: string
   gameId?: string
@@ -410,6 +410,15 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
       timestamp: Date.now()
     })
     console.log('📤 Sent leave game request')
+  }
+
+  leaveRoom(roomId: string, context: NetworkContext): void {
+    context.send({
+      type: 'leaveRoom',
+      roomId: roomId,
+      timestamp: Date.now()
+    })
+    console.log(`📤 Sent leave room request for room ${roomId}`)
   }
 
   // Session token management

--- a/src/utils/networkAdapter.ts
+++ b/src/utils/networkAdapter.ts
@@ -259,6 +259,10 @@ export class GolfNetworkAdapter {
     this.plugin.leaveGame(this.getContext())
   }
 
+  leaveRoom(roomId: string): void {
+    this.plugin.leaveRoom(roomId, this.getContext())
+  }
+
   isMyTurn(): boolean {
     return this.plugin.isMyTurn(this.getContext())
   }


### PR DESCRIPTION
Backend had leaveRoom handling but the frontend never sent it. Once you joined a room the only way out was to reload. This wires the message through the plugin/adapter/hook chain and adds a Leave Room link at the bottom of the room lobby.

Closes #216