### PR TITLE
Golf: render shared wins

### DIFF
--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -47,6 +47,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     isMyTurn,
     peekCountdown,
     winner,
+    winners,
     currentRoomPermalink,
     currentGamePermalink,
     newGameNotifications,
@@ -68,6 +69,13 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     joinNewGame,
     permalinkJoinAttempt
   } = useGolfGame({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConnectionChange, permalinkParams })
+
+  const isGameWinner = (player: Player | null | undefined) => {
+    if (!player) return false
+    const name = getDisplayName(player)
+    if (winners && winners.length > 0) return winners.includes(name)
+    return name === winner
+  }
 
   const confirmLeave = useCallback(() => {
     setShowLeaveConfirm(false)
@@ -448,10 +456,10 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
         <div className={styles.gameEndOverlay} onClick={() => setShowScores(true)}>
           <div className={styles.celebrationStage}>
             <div className={styles.celebrationEmoji}>
-              {currentPlayer && getDisplayName(currentPlayer) === winner ? '🏆' : '😤'}
+              {isGameWinner(currentPlayer) ? '🏆' : '😤'}
             </div>
             <h2 className={styles.celebrationTitle}>
-              {currentPlayer && getDisplayName(currentPlayer) === winner
+              {isGameWinner(currentPlayer)
                 ? 'You won!'
                 : `${winner} wins!`}
             </h2>
@@ -472,9 +480,9 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
               {gameState.players
                 .sort((a, b) => a.score - b.score)
                 .map((player, index) => (
-                  <div key={player.id} className={`${styles.scoreRow} ${index === 0 ? styles.winnerRow : ''}`}>
+                  <div key={player.id} className={`${styles.scoreRow} ${isGameWinner(player) ? styles.winnerRow : ''}`}>
                     <span className={styles.rank}>
-                      {index === 0 ? '👑' : `#${index + 1}`}
+                      {isGameWinner(player) ? '👑' : `#${index + 1}`}
                     </span>
                     <span className={styles.playerName}>{getDisplayName(player)}</span>
                     <span className={styles.finalScore}>{player.score} pts</span>

--- a/src/hooks/__tests__/useGolfGame.gameEnded.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.gameEnded.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useGolfGame } from '../useGolfGame'
+import type { FinalScore } from '@/types/golf'
+
+// winner/winners state from gameEnded (MoonBase#1187 phase 0): winner is the
+// display string ("alice & bob" on shared wins), winners the typed list.
+
+type GameEndedCallback = (winner: string, finalScores: FinalScore[], winners?: string[]) => void
+
+const mockAdapter = {
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  leaveGame: vi.fn(),
+  _callbacks: null as { onGameEnded?: GameEndedCallback } | null
+}
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('../../utils/networkAdapter', () => ({
+  GolfNetworkAdapter: vi.fn().mockImplementation(function (callbacks: {
+    onGameEnded?: GameEndedCallback
+  }) {
+    mockAdapter._callbacks = callbacks
+    return mockAdapter
+  })
+}))
+
+const finalScores: FinalScore[] = [
+  { playerName: 'alice', score: 5 },
+  { playerName: 'bob', score: 5 },
+  { playerName: 'carol', score: 12 }
+]
+
+describe('useGolfGame gameEnded state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAdapter._callbacks = null
+  })
+
+  it('stores the display winner and the typed winners list on a shared win', () => {
+    const { result } = renderHook(() => useGolfGame({}))
+
+    act(() => {
+      mockAdapter._callbacks?.onGameEnded?.('alice & bob', finalScores, ['alice', 'bob'])
+    })
+
+    expect(result.current.winner).toBe('alice & bob')
+    expect(result.current.winners).toEqual(['alice', 'bob'])
+    expect(result.current.finalScores).toEqual(finalScores)
+  })
+
+  it('stores null winners when a legacy server omits the list', () => {
+    const { result } = renderHook(() => useGolfGame({}))
+
+    act(() => {
+      mockAdapter._callbacks?.onGameEnded?.('alice', finalScores, undefined)
+    })
+
+    expect(result.current.winner).toBe('alice')
+    expect(result.current.winners).toBeNull()
+    expect(result.current.finalScores).toEqual(finalScores)
+  })
+
+  it('clears winner state when leaving the game', () => {
+    const { result } = renderHook(() => useGolfGame({}))
+
+    act(() => {
+      mockAdapter._callbacks?.onGameEnded?.('alice & bob', finalScores, ['alice', 'bob'])
+    })
+    act(() => {
+      result.current.leaveGame()
+    })
+
+    expect(result.current.winner).toBeNull()
+    expect(result.current.winners).toBeNull()
+    expect(result.current.finalScores).toBeNull()
+  })
+})

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -26,6 +26,7 @@ interface UseGolfGameReturn {
   isConnected: boolean
   peekCountdown: number | null
   winner: string | null
+  winners: string[] | null
   finalScores: Array<{ playerName: string; score: number }> | null
   
   // New game notifications
@@ -98,6 +99,7 @@ export const useGolfGame = ({
   const [isConnected, setIsConnected] = useState(false)
   const [peekCountdown, setPeekCountdown] = useState<number | null>(null)
   const [winner, setWinner] = useState<string | null>(null)
+  const [winners, setWinners] = useState<string[] | null>(null)
   const [finalScores, setFinalScores] = useState<Array<{ playerName: string; score: number }> | null>(null)
   const [permalinkJoinAttempt, setPermalinkJoinAttempt] = useState({
     isAttempting: false,
@@ -283,6 +285,7 @@ export const useGolfGame = ({
   const clearGameState = useCallback(() => {
     setGameState(null)
     setWinner(null)
+    setWinners(null)
     setFinalScores(null)
     setSelectedCardIndex(null)
   }, [])
@@ -291,6 +294,7 @@ export const useGolfGame = ({
     networkAdapterRef.current?.leaveGame()
     setGameState(null)
     setWinner(null)
+    setWinners(null)
     setFinalScores(null)
     setSelectedCardIndex(null)
   }, [])
@@ -304,6 +308,7 @@ export const useGolfGame = ({
     setIsInRoom(false)
     setIsInLobby(true)
     setWinner(null)
+    setWinners(null)
     setFinalScores(null)
     setSelectedCardIndex(null)
     setNewGameNotifications([])
@@ -410,6 +415,7 @@ export const useGolfGame = ({
     // Clear current game state before joining the new one
     setGameState(null)
     setWinner(null)
+    setWinners(null)
     setFinalScores(null)
     setSelectedCardIndex(null)
 
@@ -465,6 +471,7 @@ export const useGolfGame = ({
         if (gameState && !newRoomState.games[gameState.id]) {
           setGameState(null)
           setWinner(null)
+          setWinners(null)
           setFinalScores(null)
         }
       },
@@ -539,8 +546,9 @@ export const useGolfGame = ({
         setIsConnected(connected)
         onConnectionChange?.(connected)
       },
-      onGameEnded: (winnerName, scores) => {
+      onGameEnded: (winnerName, scores, winnerNames) => {
         setWinner(winnerName)
+        setWinners(winnerNames ?? null)
         setFinalScores(scores)
       },
       onNewGameStarted: (gameId, _previousGameId) => {
@@ -809,6 +817,7 @@ export const useGolfGame = ({
     isConnected,
     peekCountdown,
     winner,
+    winners,
     finalScores,
   
     // New game notifications

--- a/src/plugins/__tests__/golfNetworkPlugin.gameEnded.test.ts
+++ b/src/plugins/__tests__/golfNetworkPlugin.gameEnded.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { GolfNetworkPlugin } from '../golfNetworkPlugin'
+import type { NetworkContext } from '@/types/network'
+
+// gameEnded handling: winner is the display string ("alice & bob" on shared
+// wins) and winners is the typed list (MoonBase#1187 phase 0). Legacy servers
+// omit winners entirely.
+describe('GolfNetworkPlugin - gameEnded', () => {
+  let plugin: GolfNetworkPlugin
+  let mockContext: NetworkContext
+  let onGameEnded: Mock<
+    (winner: string, finalScores: { playerName: string; score: number }[], winners?: string[]) => void
+  >
+  let onNotification: Mock<(message: string) => void>
+
+  const finalScores = [
+    { playerName: 'alice', score: 5 },
+    { playerName: 'bob', score: 5 },
+    { playerName: 'carol', score: 12 }
+  ]
+
+  beforeEach(() => {
+    onGameEnded = vi.fn()
+    onNotification = vi.fn()
+
+    mockContext = {
+      send: vi.fn(),
+      broadcast: vi.fn(),
+      getConnectionId: vi.fn(() => 'test-connection'),
+      getGameState: vi.fn(() => ({
+        playerId: null,
+        gameState: null,
+        roomState: null,
+        gameContext: null,
+        isInLobby: true
+      })) as NetworkContext['getGameState'],
+      updateGameState: vi.fn(),
+      isConnected: vi.fn(() => true)
+    }
+
+    plugin = new GolfNetworkPlugin({ onGameEnded, onNotification })
+  })
+
+  const deliverGameEnded = (message: Record<string, unknown>) => {
+    const handler = plugin.getMessageHandlers()['gameEnded']
+    handler({ type: 'gameEnded', timestamp: Date.now(), ...message }, mockContext)
+  }
+
+  it('passes the winners list through on a shared win', () => {
+    deliverGameEnded({
+      winner: 'alice & bob',
+      winners: ['alice', 'bob'],
+      finalScores
+    })
+
+    expect(onGameEnded).toHaveBeenCalledWith('alice & bob', finalScores, ['alice', 'bob'])
+    expect(onNotification).toHaveBeenCalledWith('Game over! Winner: alice & bob')
+  })
+
+  it('passes a single-element winners list through on a solo win', () => {
+    deliverGameEnded({
+      winner: 'alice',
+      winners: ['alice'],
+      finalScores
+    })
+
+    expect(onGameEnded).toHaveBeenCalledWith('alice', finalScores, ['alice'])
+  })
+
+  it('passes undefined winners for a legacy server that omits the field', () => {
+    deliverGameEnded({
+      winner: 'alice',
+      finalScores
+    })
+
+    expect(onGameEnded).toHaveBeenCalledWith('alice', finalScores, undefined)
+  })
+
+  it('does not invoke the callback without finalScores', () => {
+    deliverGameEnded({
+      winner: 'alice',
+      winners: ['alice']
+    })
+
+    expect(onGameEnded).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Unknown when the winner is missing', () => {
+    deliverGameEnded({ finalScores })
+
+    expect(onGameEnded).toHaveBeenCalledWith('Unknown', finalScores, undefined)
+    expect(onNotification).toHaveBeenCalledWith('Game over! Winner: Unknown')
+  })
+})

--- a/src/plugins/golfNetworkPlugin.ts
+++ b/src/plugins/golfNetworkPlugin.ts
@@ -24,6 +24,7 @@ interface GolfMessage extends BaseNetworkMessage {
   roomState?: Room
   message?: string
   winner?: string
+  winners?: string[]
   finalScores?: FinalScore[]
   previousGameId?: string
   reconnected?: boolean
@@ -47,7 +48,7 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
   private onGameStateUpdate?: (gameState: GolfGameState) => void
   private onRoomStateUpdate?: (roomState: Room) => void
   private onNotification?: (message: string) => void
-  private onGameEnded?: (winner: string, finalScores: FinalScore[]) => void
+  private onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
   private onNewGameStarted?: (gameId: string, previousGameId?: string) => void
   private onReconnecting?: () => void
   private onGameError?: (message: string) => void
@@ -58,7 +59,7 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
     onGameStateUpdate?: (gameState: GolfGameState) => void
     onRoomStateUpdate?: (roomState: Room) => void
     onNotification?: (message: string) => void
-    onGameEnded?: (winner: string, finalScores: FinalScore[]) => void
+    onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
     onNewGameStarted?: (gameId: string, previousGameId?: string) => void
     onReconnecting?: () => void
     onGameError?: (message: string) => void
@@ -250,9 +251,10 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
       console.log('Final scores:', message.finalScores)
     }
     
-    // Call the onGameEnded callback if provided
+    // Call the onGameEnded callback if provided. winners is the typed
+    // list on shared wins; winner stays the display string ("a & b").
     if (this.onGameEnded && message.finalScores) {
-      this.onGameEnded(winner, message.finalScores)
+      this.onGameEnded(winner, message.finalScores, message.winners)
     }
   }
 

--- a/src/utils/networkAdapter.ts
+++ b/src/utils/networkAdapter.ts
@@ -111,7 +111,7 @@ export class GolfNetworkAdapter {
     onRoomStateUpdate?: (roomState: Room) => void
     onNotification?: (message: string) => void
     onConnectionChange?: (connected: boolean) => void
-    onGameEnded?: (winner: string, finalScores: FinalScore[]) => void
+    onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
     onNewGameStarted?: (gameId: string, previousGameId?: string) => void
     onReconnecting?: () => void
     onGameError?: (message: string) => void


### PR DESCRIPTION
The backend now reports ties as shared wins: `winner` becomes a joined display string (`"alice & bob"`) and a typed `winners` list rides along. This wires that through the golf frontend.

## Changes
- **`GolfGame.tsx`** — new `isGameWinner()` helper decides the "You won!" celebration and the 👑 scoreboard crown by membership in `winners`, falling back to the old `name === winner` string compare for servers that predate the list. Every winner is crowned on the final scoreboard on a tie.
- **`useGolfGame.ts`** — added `winners` state, plumbed it through `onGameEnded`, and cleared it in every game-reset path.
- **`golfNetworkPlugin.ts` / `networkAdapter.ts`** — threaded the optional `winners?: string[]` argument through the callback signatures and message type.
- Two new test files covering hook state and plugin dispatch (shared win, solo win, legacy omission, missing scores/winner fallbacks).

## Verification
- `tsc --noEmit` — clean
- New tests — 8/8 passing
- ESLint on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8ftoV23UzNjLxoyaFQpoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8ftoV23UzNjLxoyaFQpoW)_