### PR TITLE
Golf: v2 client behind a beta switch

### DIFF
--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -2,6 +2,8 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { GameState, Player, Room } from '@/types/golf'
 import { GolfNetworkAdapter } from '@/utils/networkAdapter'
+import { GolfV2NetworkAdapter } from '@/utils/golfV2Adapter'
+import { isGolfV2Enabled } from '@/utils/golfV2'
 import type { ParsedPermalinkParams } from '@/utils/golfPermalinks'
 import { generateRoomPermalink, generateGamePermalink } from '@/utils/golfPermalinks'
 
@@ -117,7 +119,7 @@ export const useGolfGame = ({
     dismissed: boolean
   }>>([])
   const isCreatingNewGameRef = useRef(false)
-  const networkAdapterRef = useRef<GolfNetworkAdapter | null>(null)
+  const networkAdapterRef = useRef<GolfNetworkAdapter | GolfV2NetworkAdapter | null>(null)
   const permalinkTimeoutRef = useRef<number | null>(null)
   const notificationTimeoutRef = useRef<number | null>(null)
   const reconnectTimeoutRef = useRef<number | null>(null)
@@ -429,8 +431,10 @@ export const useGolfGame = ({
 
   // Initialize network adapter and connect on mount
   useEffect(() => {
-    // Create network adapter with callbacks
-    const adapter = new GolfNetworkAdapter({
+    // Create network adapter with callbacks; ?golf=v2 opts this browser
+    // into the smithy hub (MoonBase#1187 phase 3), ?golf=v1 opts out.
+    const AdapterClass = isGolfV2Enabled() ? GolfV2NetworkAdapter : GolfNetworkAdapter
+    const adapter = new AdapterClass({
       onReconnecting: () => {
         setIsReconnecting(true)
         // Safety: clear after 2s in case server has no state to restore
@@ -583,7 +587,7 @@ export const useGolfGame = ({
 
     networkAdapterRef.current = adapter
 
-    // Connect to server
+    // Connect to server (the v2 adapter resolves its own endpoints)
     const websocketUrl = import.meta.env.VITE_GOLF_WEBSOCKET_URL || 'wss://api.muchq.com/games/v1/golf-ws'
     adapter.connect(websocketUrl)
 

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -4,6 +4,7 @@ import type { GameState, Player, Room } from '@/types/golf'
 import { GolfNetworkAdapter } from '@/utils/networkAdapter'
 import { GolfV2NetworkAdapter } from '@/utils/golfV2Adapter'
 import { isGolfV2Enabled } from '@/utils/golfV2'
+import type { GolfGameAdapter } from '@/types/golfAdapter'
 import type { ParsedPermalinkParams } from '@/utils/golfPermalinks'
 import { generateRoomPermalink, generateGamePermalink } from '@/utils/golfPermalinks'
 
@@ -119,7 +120,7 @@ export const useGolfGame = ({
     dismissed: boolean
   }>>([])
   const isCreatingNewGameRef = useRef(false)
-  const networkAdapterRef = useRef<GolfNetworkAdapter | GolfV2NetworkAdapter | null>(null)
+  const networkAdapterRef = useRef<GolfGameAdapter | null>(null)
   const permalinkTimeoutRef = useRef<number | null>(null)
   const notificationTimeoutRef = useRef<number | null>(null)
   const reconnectTimeoutRef = useRef<number | null>(null)

--- a/src/plugins/golfNetworkPlugin.ts
+++ b/src/plugins/golfNetworkPlugin.ts
@@ -6,6 +6,16 @@ import type {
   NetworkContext
 } from '@/types/network'
 import type { Player, GameState as GolfGameState, Room, FinalScore } from '@/types/golf'
+import type { GolfAdapterCallbacks } from '@/types/golfAdapter'
+import {
+  JOINED_ROOM,
+  JOINED_GAME,
+  NEW_GAME,
+  GAME_STARTED,
+  turnMessage,
+  knockedMessage,
+  gameOverMessage
+} from '@/utils/golfNotifications'
 
 // Golf-specific message types
 interface GolfMessage extends BaseNetworkMessage {
@@ -53,17 +63,8 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
   private onReconnecting?: () => void
   private onGameError?: (message: string) => void
 
-  constructor(callbacks?: {
-    onRoomJoined?: (playerId: string, roomState: Room) => void
-    onGameJoined?: (playerId: string, gameState: GolfGameState) => void
-    onGameStateUpdate?: (gameState: GolfGameState) => void
-    onRoomStateUpdate?: (roomState: Room) => void
-    onNotification?: (message: string) => void
-    onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
-    onNewGameStarted?: (gameId: string, previousGameId?: string) => void
-    onReconnecting?: () => void
-    onGameError?: (message: string) => void
-  }) {
+  // onConnectionChange is unused here — the NetworkManager owns it.
+  constructor(callbacks?: GolfAdapterCallbacks) {
     if (callbacks) {
       this.onRoomJoined = callbacks.onRoomJoined
       this.onGameJoined = callbacks.onGameJoined
@@ -150,7 +151,7 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
       this.onRoomJoined(message.playerId, message.roomState)
     }
     
-    this.notify('Joined room successfully!', context)
+    this.notify(JOINED_ROOM, context)
   }
 
   private handleRoomStateUpdate(message: GolfMessage, context: NetworkContext): void {
@@ -188,7 +189,7 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
       this.onGameJoined(message.playerId, message.gameState)
     }
     
-    this.notify('Joined game successfully!', context)
+    this.notify(JOINED_GAME, context)
   }
 
   private handleGameState(message: GolfMessage, context: NetworkContext): void {
@@ -226,25 +227,25 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
 
   private handleGameStarted(_message: GolfMessage, context: NetworkContext): void {
     console.log('🎮 Game started!')
-    this.notify('Game started! Each player can peek at 2 cards.', context)
+    this.notify(GAME_STARTED, context)
   }
 
   private handleTurnChanged(message: GolfMessage, context: NetworkContext): void {
     const playerName = (message as GolfMessage & { playerName?: string }).playerName || 'Unknown'
     console.log(`🔄 Turn changed to ${playerName}`)
-    this.notify(`It's ${playerName}'s turn`, context)
+    this.notify(turnMessage(playerName), context)
   }
 
   private handlePlayerKnocked(message: GolfMessage, context: NetworkContext): void {
     const playerName = (message as GolfMessage & { playerName?: string }).playerName || 'Unknown'
     console.log(`🔔 ${playerName} has knocked!`)
-    this.notify(`${playerName} has knocked! Last round!`, context)
+    this.notify(knockedMessage(playerName), context)
   }
 
   private handleGameEnded(message: GolfMessage, context: NetworkContext): void {
     const winner = message.winner || 'Unknown'
     console.log(`🏆 Game ended! Winner: ${winner}`)
-    this.notify(`Game over! Winner: ${winner}`, context)
+    this.notify(gameOverMessage(winner), context)
     
     // Log final scores if provided
     if (message.finalScores) {
@@ -263,7 +264,7 @@ export class GolfNetworkPlugin implements GameNetworkPlugin {
     const previousGameId = message.previousGameId
 
     console.log(`🆕 New game started in room! Game ID: ${gameId}${previousGameId ? `, Previous: ${previousGameId}` : ''}`)
-    this.notify('New game started!', context)
+    this.notify(NEW_GAME, context)
 
     if (this.onNewGameStarted && gameId) {
       this.onNewGameStarted(gameId, previousGameId)

--- a/src/types/golfAdapter.ts
+++ b/src/types/golfAdapter.ts
@@ -1,0 +1,46 @@
+import type { GameState, Room, FinalScore, Player } from './golf'
+
+// The one adapter contract useGolfGame depends on. Both the v1
+// GolfNetworkAdapter and the v2 GolfV2NetworkAdapter implement this, so
+// the "?golf=v2 swaps the wire, not the UI" premise is a compile-time
+// fact rather than two surfaces trusted to stay identical.
+
+export interface GolfAdapterCallbacks {
+  onRoomJoined?: (playerId: string, roomState: Room) => void
+  onGameJoined?: (playerId: string, gameState: GameState) => void
+  onGameStateUpdate?: (gameState: GameState) => void
+  onRoomStateUpdate?: (roomState: Room) => void
+  onNotification?: (message: string) => void
+  onConnectionChange?: (connected: boolean) => void
+  onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
+  onNewGameStarted?: (gameId: string, previousGameId?: string) => void
+  onReconnecting?: () => void
+  onGameError?: (message: string) => void
+}
+
+export interface GolfGameAdapter {
+  connect(url: string): void
+  disconnect(): void
+  readonly isConnected: boolean
+  readonly playerId: string | null
+  readonly gameState: GameState | null
+  readonly roomState: Room | null
+
+  createRoom(): void
+  joinRoom(roomId: string): void
+  leaveRoom(roomId: string): void
+  createGame(roomId: string): void
+  joinGame(roomId: string, gameId: string): void
+  startGame(): void
+  startNewGame(): void
+  leaveGame(): void
+  peekCard(cardIndex: number): void
+  drawCard(): void
+  takeFromDiscard(): void
+  swapCard(cardIndex: number): void
+  discardDrawn(): void
+  knock(): void
+  hideCards(): void
+  isMyTurn(): boolean
+  getCurrentPlayer(): Player | null
+}

--- a/src/utils/__tests__/golfV2.test.ts
+++ b/src/utils/__tests__/golfV2.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { isGolfV2Enabled, golfV2SessionUrl } from '../golfV2'
+
+describe('golf v2 beta switch', () => {
+  const setSearch = (search: string) => {
+    vi.stubGlobal('location', { ...window.location, search })
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults off', () => {
+    setSearch('')
+    expect(isGolfV2Enabled()).toBe(false)
+  })
+
+  it('?golf=v2 opts in and sticks', () => {
+    setSearch('?golf=v2')
+    expect(isGolfV2Enabled()).toBe(true)
+
+    setSearch('')
+    expect(isGolfV2Enabled()).toBe(true) // persisted
+  })
+
+  it('?golf=v1 opts back out and sticks', () => {
+    localStorage.setItem('golf_v2_beta', '1')
+    setSearch('?golf=v1')
+    expect(isGolfV2Enabled()).toBe(false)
+
+    setSearch('')
+    expect(isGolfV2Enabled()).toBe(false)
+  })
+
+  it('derives the session url from the play url', () => {
+    expect(golfV2SessionUrl()).toBe('https://api.muchq.com/games/v2/session')
+  })
+})

--- a/src/utils/__tests__/golfV2Adapter.test.ts
+++ b/src/utils/__tests__/golfV2Adapter.test.ts
@@ -174,8 +174,7 @@ describe('GolfV2NetworkAdapter', () => {
     expect(state.id).toBe('GAME01')
     expect(state.currentPlayerIndex).toBe(1) // bob
     expect(state.drawPile).toBe(40)
-    expect(state.discardPile).toHaveLength(3)
-    expect(state.discardPile[2]).toEqual({ rank: 'Q', suit: '♥' })
+    expect(state.discardPile).toEqual([{ rank: 'Q', suit: '♥' }])
     expect(state.players[0].cards).toEqual([{ rank: 'A', suit: '♠' }, null, null, null])
     expect(state.players[0].revealedCards).toEqual([0])
     expect(state.players[1].hasPeeked).toBe(true)
@@ -191,7 +190,7 @@ describe('GolfV2NetworkAdapter', () => {
     adapter.takeFromDiscard()
     expect(ws.sent.length).toBe(sentBefore) // nothing left the browser
     expect(adapter.gameState?.drawnCard).toEqual({ rank: 'Q', suit: '♥' })
-    expect(adapter.gameState?.discardPile).toHaveLength(2)
+    expect(adapter.gameState?.discardPile).toHaveLength(0)
 
     adapter.swapCard(2)
     expect(ws.lastSent()).toEqual({
@@ -217,18 +216,18 @@ describe('GolfV2NetworkAdapter', () => {
     adapter.discardDrawn()
     expect(ws.sent.length).toBe(sentBefore)
     expect(adapter.gameState?.drawnCard).toBeNull()
-    expect(adapter.gameState?.discardPile).toHaveLength(3)
+    expect(adapter.gameState?.discardPile).toEqual([{ rank: 'Q', suit: '♥' }])
   })
 
-  it('swallows the gameCreated echo for its own create, announces others', async () => {
+  it('swallows its own gameCreated echo by creator id, announces others', async () => {
     const [adapter, ws] = await connect()
 
     adapter.createGame('ignored-room-id')
     expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { createGame: {} } } })
-    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME01' } } })
+    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME01', createdBy: 'alice' } } })
     expect(callbacks.onNewGameStarted).not.toHaveBeenCalled()
 
-    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME02' } } })
+    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME02', createdBy: 'bob' } } })
     expect(callbacks.onNewGameStarted).toHaveBeenCalledWith('GAME02')
   })
 
@@ -293,8 +292,6 @@ describe('GolfV2NetworkAdapter', () => {
     const [adapter, ws] = await connect()
     adapter.joinRoom('ROOM77')
     expect(ws.lastSent()).toEqual({ event: 'joinRoom', payload: { roomId: 'ROOM77' } })
-    adapter.sendChat('hello!')
-    expect(ws.lastSent()).toEqual({ event: 'chat', payload: { text: 'hello!' } })
     adapter.drawCard()
     expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { drawCard: {} } } })
     adapter.peekCard(3)
@@ -305,4 +302,159 @@ describe('GolfV2NetworkAdapter', () => {
     adapter.knock()
     expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { knock: {} } } })
   })
+  it('maps an ended view: knocker, held card, absent current player, empty pile', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', {
+      update: {
+        gameState: {
+          view: {
+            ...sampleView,
+            phase: 'ended',
+            currentPlayerId: undefined,
+            knockedPlayerId: 'bob',
+            drawnCard: { rank: '7', suit: '♦' },
+            allPlayersPeeked: true,
+            discardTop: undefined,
+            discardCount: 0
+          }
+        }
+      }
+    })
+
+    const state = adapter.gameState as GameState
+    expect(state.gamePhase).toBe('ended')
+    expect(state.currentPlayerIndex).toBe(0) // absent current player defaults to seat 0
+    expect(state.knockedPlayerId).toBe('bob')
+    expect(state.drawnCard).toEqual({ rank: '7', suit: '♦' })
+    expect(state.allPlayersPeeked).toBe(true)
+    expect(state.discardPile).toEqual([])
+  })
+
+  it('delivers gameJoined with the mapped state', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', { update: { gameJoined: { view: sampleView } } })
+    expect(callbacks.onGameJoined).toHaveBeenCalledTimes(1)
+    const [playerId, state] = callbacks.onGameJoined.mock.calls[0]
+    expect(playerId).toBe('alice')
+    expect(state.id).toBe('GAME01')
+    expect(callbacks.onNotification).toHaveBeenCalledWith('Joined game successfully!')
+    expect(adapter.gameState?.id).toBe('GAME01')
+  })
+
+  it('gameLeft clears the held game state', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', { update: { gameState: { view: sampleView } } })
+    expect(adapter.gameState).not.toBeNull()
+    ws.receive('golf', { update: { gameLeft: { gameId: 'GAME01' } } })
+    expect(adapter.gameState).toBeNull()
+  })
+
+  it('takeFromDiscard is a no-op with nothing on the pile', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', {
+      update: { gameState: { view: { ...sampleView, discardTop: undefined, discardCount: 0 } } }
+    })
+    const updates = callbacks.onGameStateUpdate.mock.calls.length
+    adapter.takeFromDiscard()
+    expect(callbacks.onGameStateUpdate).toHaveBeenCalledTimes(updates)
+    expect(adapter.gameState?.drawnCard).toBeNull()
+  })
+
+  it('leaveRoom sends the envelope and re-announces the next room', async () => {
+    const [adapter, ws] = await connect()
+    const room = { roomId: 'ROOM01', players: [], games: [] }
+    ws.receive('roomState', room)
+    expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(1)
+
+    adapter.leaveRoom('ROOM01')
+    expect(ws.lastSent()).toEqual({ event: 'leaveRoom', payload: {} })
+
+    ws.receive('roomState', room)
+    expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(2)
+  })
+
+  it('signals connection state on open and close', async () => {
+    const [, ws] = await connect()
+    expect(callbacks.onConnectionChange).toHaveBeenCalledWith(true)
+    ws.close()
+    expect(callbacks.onConnectionChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('re-dials with a fresh mint after an abrupt close', async () => {
+    vi.useFakeTimers()
+    try {
+      const adapter = new GolfV2NetworkAdapter(callbacks)
+      adapter.connect()
+      await vi.advanceTimersByTimeAsync(0)
+      const first = FakeWebSocket.instances[0]
+      first.open()
+      first.receive('sessionReady', { playerId: 'alice', resumed: false })
+
+      first.close() // abrupt loss
+      await vi.advanceTimersByTimeAsync(2000)
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      // The re-mint rides the stored resume token, so the seat resumes.
+      const [, init] = fetchMock.mock.calls[1]
+      expect(JSON.parse((init as { body: string }).body)).toEqual({ resumeToken: 'rt-456' })
+      expect(FakeWebSocket.instances).toHaveLength(2)
+      adapter.disconnect()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a failed mint schedules a retry', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 503 })
+      const adapter = new GolfV2NetworkAdapter(callbacks)
+      adapter.connect()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(FakeWebSocket.instances).toHaveLength(0)
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(FakeWebSocket.instances).toHaveLength(1)
+      adapter.disconnect()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('disconnect stops the reconnect loop', async () => {
+    vi.useFakeTimers()
+    try {
+      const adapter = new GolfV2NetworkAdapter(callbacks)
+      adapter.connect()
+      await vi.advanceTimersByTimeAsync(0)
+      FakeWebSocket.instances[0].open()
+
+      adapter.disconnect()
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('gives up with an error after the reconnect budget', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockRejectedValue(new Error('down'))
+      const adapter = new GolfV2NetworkAdapter(callbacks)
+      adapter.connect()
+      await vi.advanceTimersByTimeAsync(0)
+      for (let i = 0; i < 10; i++) {
+        await vi.advanceTimersByTimeAsync(2000)
+      }
+      expect(callbacks.onGameError).toHaveBeenCalledWith('Lost connection to the golf server')
+      expect(fetchMock).toHaveBeenCalledTimes(11)
+      adapter.disconnect()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
 })

--- a/src/utils/__tests__/golfV2Adapter.test.ts
+++ b/src/utils/__tests__/golfV2Adapter.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { GolfV2NetworkAdapter } from '../golfV2Adapter'
+import type { GolfAdapterCallbacks } from '../golfV2Adapter'
+import type { GameState } from '@/types/golf'
+
+type MockedCallbacks = {
+  [K in keyof Required<GolfAdapterCallbacks>]: Mock<Required<GolfAdapterCallbacks>[K]>
+}
+
+// The v2 adapter against a scripted wire: session mint, the smithy
+// JSON-text envelopes, v2->v1 shape translation, and the local
+// take-from-discard emulation (MoonBase#1187 phase 3).
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  static OPEN = 1
+  readonly OPEN = 1
+  url: string
+  protocol: string
+  readyState = 0
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(url: string, protocol: string) {
+    this.url = url
+    this.protocol = protocol
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.onclose?.()
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.onopen?.()
+  }
+
+  receive(event: string, payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify({ event, payload }) })
+  }
+
+  lastSent(): { event: string; payload: Record<string, unknown> } {
+    return JSON.parse(this.sent[this.sent.length - 1])
+  }
+}
+
+const flushAsync = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('GolfV2NetworkAdapter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let callbacks: MockedCallbacks
+
+  const sampleView = {
+    gameId: 'GAME01',
+    phase: 'playing' as const,
+    players: [
+      {
+        playerId: 'alice',
+        cards: [{ card: { rank: 'A', suit: '♠' } }, {}, {}, {}],
+        revealedIndexes: [0],
+        hasPeeked: false
+      },
+      { playerId: 'bob', cards: [{}, {}, {}, {}], revealedIndexes: [], hasPeeked: true }
+    ],
+    currentPlayerId: 'bob',
+    drawPileCount: 40,
+    discardCount: 3,
+    discardTop: { rank: 'Q', suit: '♥' },
+    allPlayersPeeked: false
+  }
+
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({ playerId: 'alice', ticket: 't-123', resumeToken: 'rt-456' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    localStorage.clear()
+    callbacks = {
+      onRoomJoined: vi.fn(),
+      onGameJoined: vi.fn(),
+      onGameStateUpdate: vi.fn(),
+      onRoomStateUpdate: vi.fn(),
+      onNotification: vi.fn(),
+      onConnectionChange: vi.fn(),
+      onGameEnded: vi.fn(),
+      onNewGameStarted: vi.fn(),
+      onReconnecting: vi.fn(),
+      onGameError: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const connect = async (): Promise<[GolfV2NetworkAdapter, FakeWebSocket]> => {
+    const adapter = new GolfV2NetworkAdapter(callbacks)
+    adapter.connect()
+    await flushAsync()
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.receive('sessionReady', { playerId: 'alice', resumed: false })
+    return [adapter, ws]
+  }
+
+  it('mints a session, stores the resume token, and dials with the ticket', async () => {
+    const [, ws] = await connect()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/games/v2/session')
+    expect(JSON.parse((init as { body: string }).body)).toEqual({})
+
+    expect(ws.url).toContain('?ticket=t-123')
+    expect(ws.protocol).toBe('smithy.eventstream.v1+json')
+    expect(localStorage.getItem('golf_v2_resume_token')).toBe('rt-456')
+  })
+
+  it('re-mints with the stored resume token', async () => {
+    localStorage.setItem('golf_v2_resume_token', 'rt-old')
+    await connect()
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse((init as { body: string }).body)).toEqual({ resumeToken: 'rt-old' })
+  })
+
+  it('announces a room once, then streams updates', async () => {
+    const [, ws] = await connect()
+    const room = {
+      roomId: 'ROOM01',
+      players: [
+        { playerId: 'alice', connected: true, gamesPlayed: 2, gamesWon: 1, totalScore: 7 }
+      ],
+      games: [{ gameId: 'GAME01', status: 'waiting', playerCount: 1 }]
+    }
+
+    ws.receive('roomState', room)
+    expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(1)
+    const [playerId, mapped] = callbacks.onRoomJoined.mock.calls[0]
+    expect(playerId).toBe('alice')
+    expect(mapped.id).toBe('ROOM01')
+    expect(mapped.players[0].totalScore).toBe(7)
+    expect(mapped.players[0].gamesWon).toBe(1)
+    expect(mapped.games['GAME01'].gamePhase).toBe('waiting')
+    expect(mapped.games['GAME01'].players).toHaveLength(1)
+
+    ws.receive('roomState', { ...room, games: [] })
+    expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(1)
+    expect(callbacks.onRoomStateUpdate).toHaveBeenCalledTimes(1)
+
+    ws.receive('roomLeft', { roomId: 'ROOM01' })
+    ws.receive('roomState', room)
+    expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(2)
+  })
+
+  it('translates game views into the v1 shape', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', { update: { gameState: { view: sampleView } } })
+
+    const state = adapter.gameState as GameState
+    expect(state.id).toBe('GAME01')
+    expect(state.currentPlayerIndex).toBe(1) // bob
+    expect(state.drawPile).toBe(40)
+    expect(state.discardPile).toHaveLength(3)
+    expect(state.discardPile[2]).toEqual({ rank: 'Q', suit: '♥' })
+    expect(state.players[0].cards).toEqual([{ rank: 'A', suit: '♠' }, null, null, null])
+    expect(state.players[0].revealedCards).toEqual([0])
+    expect(state.players[1].hasPeeked).toBe(true)
+    expect(state.drawnCard).toBeNull()
+    expect(callbacks.onGameStateUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('emulates take-from-discard locally and sends on placement', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', { update: { gameState: { view: sampleView } } })
+    const sentBefore = ws.sent.length
+
+    adapter.takeFromDiscard()
+    expect(ws.sent.length).toBe(sentBefore) // nothing left the browser
+    expect(adapter.gameState?.drawnCard).toEqual({ rank: 'Q', suit: '♥' })
+    expect(adapter.gameState?.discardPile).toHaveLength(2)
+
+    adapter.swapCard(2)
+    expect(ws.lastSent()).toEqual({
+      event: 'golf',
+      payload: { move: { takeFromDiscard: { cardIndex: 2 } } }
+    })
+
+    // A fresh server view ends any emulation; a plain swap goes out as-is.
+    ws.receive('golf', { update: { gameState: { view: sampleView } } })
+    adapter.swapCard(1)
+    expect(ws.lastSent()).toEqual({
+      event: 'golf',
+      payload: { move: { swapCard: { cardIndex: 1 } } }
+    })
+  })
+
+  it('putting the taken discard back restores the server view silently', async () => {
+    const [adapter, ws] = await connect()
+    ws.receive('golf', { update: { gameState: { view: sampleView } } })
+    const sentBefore = ws.sent.length
+
+    adapter.takeFromDiscard()
+    adapter.discardDrawn()
+    expect(ws.sent.length).toBe(sentBefore)
+    expect(adapter.gameState?.drawnCard).toBeNull()
+    expect(adapter.gameState?.discardPile).toHaveLength(3)
+  })
+
+  it('swallows the gameCreated echo for its own create, announces others', async () => {
+    const [adapter, ws] = await connect()
+
+    adapter.createGame('ignored-room-id')
+    expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { createGame: {} } } })
+    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME01' } } })
+    expect(callbacks.onNewGameStarted).not.toHaveBeenCalled()
+
+    ws.receive('golf', { update: { gameCreated: { gameId: 'GAME02' } } })
+    expect(callbacks.onNewGameStarted).toHaveBeenCalledWith('GAME02')
+  })
+
+  it('maps gameEnded scores and passes the winners list through', async () => {
+    const [, ws] = await connect()
+    ws.receive('golf', {
+      update: {
+        gameEnded: {
+          winner: 'alice & bob',
+          winners: ['alice', 'bob'],
+          finalScores: [
+            { playerId: 'alice', score: 0 },
+            { playerId: 'bob', score: 0 }
+          ]
+        }
+      }
+    })
+    expect(callbacks.onGameEnded).toHaveBeenCalledWith(
+      'alice & bob',
+      [
+        { playerName: 'alice', score: 0 },
+        { playerName: 'bob', score: 0 }
+      ],
+      ['alice', 'bob']
+    )
+  })
+
+  it('surfaces rejections in-band and keeps the session', async () => {
+    const [, ws] = await connect()
+    ws.receive('commandRejected', { reason: 'not your turn' })
+    expect(callbacks.onGameError).toHaveBeenCalledWith('not your turn')
+    expect(localStorage.getItem('golf_v2_resume_token')).toBe('rt-456')
+  })
+
+  it('signals a resumed session', async () => {
+    const adapter = new GolfV2NetworkAdapter(callbacks)
+    adapter.connect()
+    await flushAsync()
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.receive('sessionReady', { playerId: 'alice', resumed: true, roomId: 'ROOM01' })
+    expect(callbacks.onReconnecting).toHaveBeenCalledTimes(1)
+    adapter.disconnect()
+  })
+
+  it('drops the resume token when refused before admission', async () => {
+    const adapter = new GolfV2NetworkAdapter(callbacks)
+    adapter.connect()
+    await flushAsync()
+    expect(localStorage.getItem('golf_v2_resume_token')).toBe('rt-456')
+
+    // Closed without ever seeing sessionReady: spent ticket or seat
+    // conflict — the next dial must mint fresh.
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.close()
+    expect(localStorage.getItem('golf_v2_resume_token')).toBeNull()
+    adapter.disconnect()
+  })
+
+  it('sends room commands as bare envelopes and moves inside golf', async () => {
+    const [adapter, ws] = await connect()
+    adapter.joinRoom('ROOM77')
+    expect(ws.lastSent()).toEqual({ event: 'joinRoom', payload: { roomId: 'ROOM77' } })
+    adapter.sendChat('hello!')
+    expect(ws.lastSent()).toEqual({ event: 'chat', payload: { text: 'hello!' } })
+    adapter.drawCard()
+    expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { drawCard: {} } } })
+    adapter.peekCard(3)
+    expect(ws.lastSent()).toEqual({
+      event: 'golf',
+      payload: { move: { peekCard: { cardIndex: 3 } } }
+    })
+    adapter.knock()
+    expect(ws.lastSent()).toEqual({ event: 'golf', payload: { move: { knock: {} } } })
+  })
+})

--- a/src/utils/golfNotifications.ts
+++ b/src/utils/golfNotifications.ts
@@ -1,0 +1,11 @@
+// User-facing golf notification strings, shared by the v1 plugin and the
+// v2 adapter so the same game event reads identically on either wire.
+
+export const JOINED_ROOM = 'Joined room successfully!'
+export const JOINED_GAME = 'Joined game successfully!'
+export const NEW_GAME = 'New game started!'
+export const GAME_STARTED = 'Game started! Each player can peek at 2 cards.'
+
+export const turnMessage = (player: string) => `It's ${player}'s turn`
+export const knockedMessage = (player: string) => `${player} has knocked! Last round!`
+export const gameOverMessage = (winner: string) => `Game over! Winner: ${winner}`

--- a/src/utils/golfV2.ts
+++ b/src/utils/golfV2.ts
@@ -1,0 +1,39 @@
+// The golf v2 beta switch and endpoints (MoonBase#1187 phase 3).
+//
+// v2 is the smithy event-stream hub. Opt in per browser with ?golf=v2
+// (sticky via localStorage), opt back out with ?golf=v1. A build can
+// default everyone in with VITE_GOLF_V2_DEFAULT=true.
+
+const V2_FLAG_KEY = 'golf_v2_beta'
+
+export function isGolfV2Enabled(): boolean {
+  try {
+    const param = new URLSearchParams(window.location.search).get('golf')
+    if (param === 'v2') {
+      localStorage.setItem(V2_FLAG_KEY, '1')
+      return true
+    }
+    if (param === 'v1') {
+      localStorage.setItem(V2_FLAG_KEY, '0')
+      return false
+    }
+    const stored = localStorage.getItem(V2_FLAG_KEY)
+    if (stored === '1') return true
+    if (stored === '0') return false
+  } catch {
+    // Private mode etc. — fall through to the build default.
+  }
+  return import.meta.env.VITE_GOLF_V2_DEFAULT === 'true'
+}
+
+export function golfV2PlayUrl(): string {
+  return import.meta.env.VITE_GOLF_V2_WEBSOCKET_URL || 'wss://api.muchq.com/games/v2/golf/play'
+}
+
+/// The session mint lives beside the play socket: same origin, http(s)
+/// for ws(s), /games/v2/session.
+export function golfV2SessionUrl(): string {
+  const play = new URL(golfV2PlayUrl())
+  const protocol = play.protocol === 'wss:' ? 'https:' : 'http:'
+  return `${protocol}//${play.host}/games/v2/session`
+}

--- a/src/utils/golfV2.ts
+++ b/src/utils/golfV2.ts
@@ -4,25 +4,25 @@
 // (sticky via localStorage), opt back out with ?golf=v1. A build can
 // default everyone in with VITE_GOLF_V2_DEFAULT=true.
 
+import { safeLocalStorage } from './safeLocalStorage'
+
 const V2_FLAG_KEY = 'golf_v2_beta'
 
+// Deliberately impure: seeing ?golf=v2 (or v1) persists the choice, so
+// the query param is a one-visit opt-in that sticks.
 export function isGolfV2Enabled(): boolean {
-  try {
-    const param = new URLSearchParams(window.location.search).get('golf')
-    if (param === 'v2') {
-      localStorage.setItem(V2_FLAG_KEY, '1')
-      return true
-    }
-    if (param === 'v1') {
-      localStorage.setItem(V2_FLAG_KEY, '0')
-      return false
-    }
-    const stored = localStorage.getItem(V2_FLAG_KEY)
-    if (stored === '1') return true
-    if (stored === '0') return false
-  } catch {
-    // Private mode etc. — fall through to the build default.
+  const param = new URLSearchParams(window.location.search).get('golf')
+  if (param === 'v2') {
+    safeLocalStorage.set(V2_FLAG_KEY, '1')
+    return true
   }
+  if (param === 'v1') {
+    safeLocalStorage.set(V2_FLAG_KEY, '0')
+    return false
+  }
+  const stored = safeLocalStorage.get(V2_FLAG_KEY)
+  if (stored === '1') return true
+  if (stored === '0') return false
   return import.meta.env.VITE_GOLF_V2_DEFAULT === 'true'
 }
 
@@ -30,8 +30,8 @@ export function golfV2PlayUrl(): string {
   return import.meta.env.VITE_GOLF_V2_WEBSOCKET_URL || 'wss://api.muchq.com/games/v2/golf/play'
 }
 
-/// The session mint lives beside the play socket: same origin, http(s)
-/// for ws(s), /games/v2/session.
+// The session mint lives beside the play socket: same origin, http(s)
+// for ws(s), /games/v2/session.
 export function golfV2SessionUrl(): string {
   const play = new URL(golfV2PlayUrl())
   const protocol = play.protocol === 'wss:' ? 'https:' : 'http:'

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 // The golf v2 client (MoonBase#1187 phase 3): the smithy event-stream
-// wire, presented through the exact same adapter surface as the v1
+// wire, presented through the same GolfGameAdapter surface as the v1
 // GolfNetworkAdapter so useGolfGame and the components don't change.
 //
 // Wire shape (smithy-cpp ADR-0018 JSON-text mode):
@@ -12,20 +12,42 @@
 //
 // Two deliberate translations keep the v1 UI untouched:
 //   - v2 GameView -> v1 GameState (ids to indexes, slots to nullable
-//     cards, discard top+count to a pile array).
+//     cards). Bridge-lifetime shims, gone with v1 in phase 5: the
+//     discard renders as a one-card pile (v2 sends top + count; only the
+//     top is drawn), room game summaries carry fake seat players to
+//     satisfy the v1 Player[] shape, and gameHistory is empty — the v2
+//     wire doesn't carry it, so the "Recent Games" panel is blank on v2.
 //   - v1's take-then-place discard flow is emulated locally: the discard
 //     top is public, so "taking" it reveals nothing; the real v2
 //     takeFromDiscard{cardIndex} is sent when the player places it.
 
 import type { Card, GameState as GolfGameState, Player, Room, FinalScore } from '@/types/golf'
+import type { GolfAdapterCallbacks, GolfGameAdapter } from '@/types/golfAdapter'
+import {
+  JOINED_ROOM,
+  JOINED_GAME,
+  NEW_GAME,
+  GAME_STARTED,
+  turnMessage,
+  knockedMessage,
+  gameOverMessage
+} from './golfNotifications'
+import { safeLocalStorage } from './safeLocalStorage'
 import { golfV2PlayUrl, golfV2SessionUrl } from './golfV2'
+
+export type { GolfAdapterCallbacks } from '@/types/golfAdapter'
 
 const RESUME_TOKEN_KEY = 'golf_v2_resume_token'
 const SUBPROTOCOL = 'smithy.eventstream.v1+json'
+const MINT_TIMEOUT_MS = 10_000
+// 2s x 10 covers the hub's 5-minute reconnect grace, matching the v1
+// adapter's tuning (networkAdapter.ts connect config).
 const RECONNECT_DELAY_MS = 2000
 const MAX_RECONNECT_ATTEMPTS = 10
 
 // --- v2 wire shapes (mirrors model/games.smithy + model/golf_hub.smithy) ---
+
+type GamePhase = GolfGameState['gamePhase']
 
 interface V2CardSlot {
   card?: Card
@@ -41,7 +63,7 @@ interface V2GamePlayer {
 
 interface V2GameView {
   gameId: string
-  phase: 'waiting' | 'playing' | 'peeking' | 'knocked' | 'ended'
+  phase: GamePhase
   players: V2GamePlayer[]
   currentPlayerId?: string
   drawPileCount: number
@@ -62,7 +84,7 @@ interface V2PlayerInfo {
 
 interface V2GameSummary {
   gameId: string
-  status: string
+  status: GamePhase
   playerCount: number
 }
 
@@ -72,28 +94,56 @@ interface V2RoomState {
   games: V2GameSummary[]
 }
 
-interface V2Events {
-  sessionReady?: { playerId: string; resumed: boolean; roomId?: string }
-  roomState?: V2RoomState
-  roomLeft?: { roomId: string }
-  roomChat?: { playerId: string; text: string }
-  commandRejected?: { reason: string }
-  golf?: { update: V2GolfUpdate }
+interface V2SessionReady {
+  playerId: string
+  resumed: boolean
+  roomId?: string
 }
 
+// The golf update union's JSON encoding: exactly one member present.
 interface V2GolfUpdate {
   gameJoined?: { view: V2GameView }
   gameState?: { view: V2GameView }
-  gameCreated?: { gameId: string }
+  gameCreated?: { gameId: string; createdBy?: string }
   gameStarted?: Record<string, never>
   turnChanged?: { playerId: string }
   playerKnocked?: { playerId: string }
-  gameEnded?: { winner: string; winners: string[]; finalScores: { playerId: string; score: number }[] }
+  gameEnded?: {
+    winner: string
+    winners: string[]
+    finalScores: { playerId: string; score: number }[]
+  }
   gameLeft?: { gameId: string }
 }
 
+// Inbound frames as a discriminated union: the switch narrows each case,
+// and a new event is a compile-time hole instead of a silent cast.
+type V2Frame =
+  | { event: 'sessionReady'; payload: V2SessionReady }
+  | { event: 'roomState'; payload: V2RoomState }
+  | { event: 'roomLeft'; payload: { roomId: string } }
+  | { event: 'roomChat'; payload: { playerId: string; text: string } }
+  | { event: 'commandRejected'; payload: { reason: string } }
+  | { event: 'golf'; payload: { update: V2GolfUpdate } }
+
+type V2CommandEvent = 'createRoom' | 'joinRoom' | 'leaveRoom' | 'getRoomState' | 'chat' | 'golf'
+type V2MoveName =
+  | 'createGame'
+  | 'joinGame'
+  | 'startGame'
+  | 'leaveGame'
+  | 'peekCard'
+  | 'drawCard'
+  | 'takeFromDiscard'
+  | 'swapCard'
+  | 'discardDrawn'
+  | 'knock'
+  | 'hideCards'
+
 // --- v2 -> v1 shape translation ---
 
+// v2 has no separate display names: the whimsical playerId is the label,
+// so it fills both id and name.
 function stubPlayer(id: string): Player {
   return {
     id,
@@ -112,6 +162,12 @@ function stubPlayer(id: string): Player {
   }
 }
 
+// Fake seats carrying only a count — the v1 Room shape wants Player[]
+// where v2 sends playerCount, and the lobby reads only the length.
+function stubSeats(count: number): Player[] {
+  return Array.from({ length: count }, (_, i) => stubPlayer(`seat-${i}`))
+}
+
 function mapGamePlayer(player: V2GamePlayer): Player {
   return {
     ...stubPlayer(player.playerId),
@@ -123,17 +179,19 @@ function mapGamePlayer(player: V2GamePlayer): Player {
 }
 
 function mapGameView(view: V2GameView): GolfGameState {
-  // The v1 shape carries the whole discard pile; v2 sends top + count.
-  // Only the top is ever rendered, so backfill with copies of the top.
-  const discardPile: Card[] =
-    view.discardTop == null ? [] : Array<Card>(view.discardCount).fill(view.discardTop)
-  const currentPlayerIndex = view.currentPlayerId
-    ? Math.max(0, view.players.findIndex(p => p.playerId === view.currentPlayerId))
-    : 0
+  // The UI renders only the discard top, and holding the top during the
+  // take emulation must not "reveal" a card beneath that this client was
+  // never sent — so the pile maps to at most one card.
+  const discardPile: Card[] = view.discardTop == null ? [] : [view.discardTop]
+  const currentSeat = view.currentPlayerId
+    ? view.players.findIndex(p => p.playerId === view.currentPlayerId)
+    : -1
   return {
     id: view.gameId,
     players: view.players.map(mapGamePlayer),
-    currentPlayerIndex,
+    // An absent or unknown current player (e.g. an ended game) shows as
+    // seat 0; nothing turn-gated renders in those phases.
+    currentPlayerIndex: currentSeat >= 0 ? currentSeat : 0,
     drawPile: view.drawPileCount,
     discardPile,
     gamePhase: view.phase,
@@ -148,11 +206,11 @@ function mapRoomState(room: V2RoomState): Room {
   for (const summary of room.games) {
     games[summary.gameId] = {
       id: summary.gameId,
-      players: Array.from({ length: summary.playerCount }, (_, i) => stubPlayer(`seat-${i}`)),
+      players: stubSeats(summary.playerCount),
       currentPlayerIndex: 0,
       drawPile: 0,
       discardPile: [],
-      gamePhase: summary.status as GolfGameState['gamePhase'],
+      gamePhase: summary.status,
       knockedPlayerId: null,
       drawnCard: null,
       allPlayersPeeked: false
@@ -176,20 +234,7 @@ function mapRoomState(room: V2RoomState): Room {
 
 // --- the adapter ---
 
-export interface GolfAdapterCallbacks {
-  onRoomJoined?: (playerId: string, roomState: Room) => void
-  onGameJoined?: (playerId: string, gameState: GolfGameState) => void
-  onGameStateUpdate?: (gameState: GolfGameState) => void
-  onRoomStateUpdate?: (roomState: Room) => void
-  onNotification?: (message: string) => void
-  onConnectionChange?: (connected: boolean) => void
-  onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
-  onNewGameStarted?: (gameId: string, previousGameId?: string) => void
-  onReconnecting?: () => void
-  onGameError?: (message: string) => void
-}
-
-export class GolfV2NetworkAdapter {
+export class GolfV2NetworkAdapter implements GolfGameAdapter {
   private callbacks: GolfAdapterCallbacks
   private ws: WebSocket | null = null
   private _playerId: string | null = null
@@ -202,18 +247,21 @@ export class GolfV2NetworkAdapter {
 
   // The room the UI has been told it joined; the next different
   // roomState fires onRoomJoined, same-room ones fire onRoomStateUpdate.
+  // Sound because the hub only sends roomState to members: a new roomId
+  // always means this player joined (or resumed into) that room.
   private announcedRoomId: string | null = null
-  // Our in-flight createGame requests: swallow their room-wide
-  // gameCreated echo (the creator is auto-seated and gets gameJoined).
-  private pendingOwnCreates = 0
   // v1's take-then-place discard flow, emulated locally.
   private pendingDiscardTake = false
+  // The last authoritative server view, kept so the discard-take
+  // emulation can be reverted without inventing state.
   private lastServerView: V2GameView | null = null
 
   constructor(callbacks?: GolfAdapterCallbacks) {
     this.callbacks = callbacks ?? {}
   }
 
+  // The url parameter is part of the shared adapter surface; v2 resolves
+  // its own endpoints from golfV2.ts, so it is accepted and ignored.
   connect(_url?: string): void {
     this.closed = false
     void this.dial()
@@ -249,11 +297,14 @@ export class GolfV2NetworkAdapter {
 
   private async dial(): Promise<void> {
     try {
-      const stored = this.getResumeToken()
+      const stored = safeLocalStorage.get(RESUME_TOKEN_KEY)
       const response = await fetch(golfV2SessionUrl(), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(stored ? { resumeToken: stored } : {})
+        body: JSON.stringify(stored ? { resumeToken: stored } : {}),
+        // A hung server must count as a failed attempt, not stall the
+        // bounded reconnect loop forever.
+        signal: AbortSignal.timeout(MINT_TIMEOUT_MS)
       })
       if (!response.ok) {
         throw new Error(`session mint failed: ${response.status}`)
@@ -264,7 +315,7 @@ export class GolfV2NetworkAdapter {
         resumeToken: string
       }
       this._playerId = session.playerId
-      this.storeResumeToken(session.resumeToken)
+      safeLocalStorage.set(RESUME_TOKEN_KEY, session.resumeToken)
 
       const url = `${golfV2PlayUrl()}?ticket=${encodeURIComponent(session.ticket)}`
       const ws = new WebSocket(url, SUBPROTOCOL)
@@ -278,7 +329,9 @@ export class GolfV2NetworkAdapter {
       }
       ws.onmessage = event => {
         try {
-          this.handleFrame(JSON.parse(event.data as string) as { event?: string; payload?: unknown })
+          // The one boundary cast: frames are validated by shape of use,
+          // not a runtime schema — unknown events fall through the switch.
+          this.handleFrame(JSON.parse(event.data as string) as V2Frame)
         } catch (error) {
           console.error('golf v2: bad frame', error)
         }
@@ -288,7 +341,7 @@ export class GolfV2NetworkAdapter {
         if (!this.sawSessionReady) {
           // Refused before admission (spent ticket, seat conflict, bad
           // resume token): drop the token so the next dial mints fresh.
-          this.clearResumeToken()
+          safeLocalStorage.remove(RESUME_TOKEN_KEY)
         }
         this.scheduleReconnect()
       }
@@ -312,7 +365,7 @@ export class GolfV2NetworkAdapter {
     this.reconnectTimeout = window.setTimeout(() => void this.dial(), RECONNECT_DELAY_MS)
   }
 
-  private sendEvent(event: string, payload: unknown): void {
+  private sendEvent(event: V2CommandEvent, payload: unknown): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       console.warn('golf v2: cannot send, not connected')
       return
@@ -320,49 +373,40 @@ export class GolfV2NetworkAdapter {
     this.ws.send(JSON.stringify({ event, payload }))
   }
 
-  private sendMove(move: string, payload: unknown = {}): void {
+  private sendMove(move: V2MoveName, payload: unknown = {}): void {
     this.sendEvent('golf', { move: { [move]: payload } })
   }
 
   // --- inbound events ---
 
-  private handleFrame(frame: { event?: string; payload?: unknown }): void {
-    if (!frame.event) {
-      console.warn('golf v2: frame without event', frame)
-      return
-    }
-    const payload = (frame.payload ?? {}) as V2Events[keyof V2Events]
-    switch (frame.event as keyof V2Events) {
+  private handleFrame(frame: V2Frame): void {
+    switch (frame.event) {
       case 'sessionReady':
-        this.handleSessionReady(payload as NonNullable<V2Events['sessionReady']>)
+        this.handleSessionReady(frame.payload)
         return
       case 'roomState':
-        this.handleRoomState(payload as V2RoomState)
+        this.handleRoomState(frame.payload)
         return
       case 'roomLeft':
         this.announcedRoomId = null
         this._roomState = null
         return
-      case 'roomChat': {
-        const chat = payload as NonNullable<V2Events['roomChat']>
-        this.callbacks.onNotification?.(`${chat.playerId}: ${chat.text}`)
+      case 'roomChat':
+        this.callbacks.onNotification?.(`${frame.payload.playerId}: ${frame.payload.text}`)
         return
-      }
-      case 'commandRejected': {
-        const rejected = payload as NonNullable<V2Events['commandRejected']>
-        this.callbacks.onGameError?.(rejected.reason)
-        this.callbacks.onNotification?.(rejected.reason)
+      case 'commandRejected':
+        this.callbacks.onGameError?.(frame.payload.reason)
+        this.callbacks.onNotification?.(frame.payload.reason)
         return
-      }
       case 'golf':
-        this.handleUpdate((payload as NonNullable<V2Events['golf']>).update)
+        this.handleUpdate(frame.payload.update)
         return
       default:
-        console.warn(`golf v2: unknown event ${frame.event}`)
+        console.warn('golf v2: unknown event', frame)
     }
   }
 
-  private handleSessionReady(ready: { playerId: string; resumed: boolean; roomId?: string }): void {
+  private handleSessionReady(ready: V2SessionReady): void {
     this._playerId = ready.playerId
     this.sawSessionReady = true
     if (ready.resumed && ready.roomId) {
@@ -377,7 +421,7 @@ export class GolfV2NetworkAdapter {
     if (this.announcedRoomId !== room.roomId) {
       this.announcedRoomId = room.roomId
       this.callbacks.onRoomJoined?.(this._playerId ?? '', mapped)
-      this.callbacks.onNotification?.('Joined room successfully!')
+      this.callbacks.onNotification?.(JOINED_ROOM)
     } else {
       this.callbacks.onRoomStateUpdate?.(mapped)
     }
@@ -385,37 +429,36 @@ export class GolfV2NetworkAdapter {
 
   private handleUpdate(update: V2GolfUpdate): void {
     if (update.gameJoined) {
-      this.acceptView(update.gameJoined.view)
-      this.callbacks.onGameJoined?.(this._playerId ?? '', this._gameState!)
-      this.callbacks.onNotification?.('Joined game successfully!')
+      const state = this.acceptView(update.gameJoined.view)
+      this.callbacks.onGameJoined?.(this._playerId ?? '', state)
+      this.callbacks.onNotification?.(JOINED_GAME)
       return
     }
     if (update.gameState) {
-      this.acceptView(update.gameState.view)
-      this.callbacks.onGameStateUpdate?.(this._gameState!)
+      const state = this.acceptView(update.gameState.view)
+      this.callbacks.onGameStateUpdate?.(state)
       return
     }
     if (update.gameCreated) {
-      if (this.pendingOwnCreates > 0) {
+      if (update.gameCreated.createdBy === this._playerId) {
         // Our own create: the gameJoined we also receive carries the
         // state, and announcing it would make the hook double-join.
-        this.pendingOwnCreates--
         return
       }
-      this.callbacks.onNotification?.('New game started!')
+      this.callbacks.onNotification?.(NEW_GAME)
       this.callbacks.onNewGameStarted?.(update.gameCreated.gameId)
       return
     }
     if (update.gameStarted) {
-      this.callbacks.onNotification?.('Game started! Each player can peek at 2 cards.')
+      this.callbacks.onNotification?.(GAME_STARTED)
       return
     }
     if (update.turnChanged) {
-      this.callbacks.onNotification?.(`It's ${update.turnChanged.playerId}'s turn`)
+      this.callbacks.onNotification?.(turnMessage(update.turnChanged.playerId))
       return
     }
     if (update.playerKnocked) {
-      this.callbacks.onNotification?.(`${update.playerKnocked.playerId} has knocked! Last round!`)
+      this.callbacks.onNotification?.(knockedMessage(update.playerKnocked.playerId))
       return
     }
     if (update.gameEnded) {
@@ -424,7 +467,7 @@ export class GolfV2NetworkAdapter {
         playerName: score.playerId,
         score: score.score
       }))
-      this.callbacks.onNotification?.(`Game over! Winner: ${ended.winner}`)
+      this.callbacks.onNotification?.(gameOverMessage(ended.winner))
       this.callbacks.onGameEnded?.(ended.winner, finalScores, ended.winners)
       return
     }
@@ -437,15 +480,16 @@ export class GolfV2NetworkAdapter {
     console.warn('golf v2: unknown update', update)
   }
 
-  private acceptView(view: V2GameView): void {
+  private acceptView(view: V2GameView): GolfGameState {
     // Server state is authoritative: any update ends the local
     // take-from-discard emulation.
     this.lastServerView = view
     this.pendingDiscardTake = false
     this._gameState = mapGameView(view)
+    return this._gameState
   }
 
-  // --- actions (the v1 adapter surface) ---
+  // --- actions (the shared GolfGameAdapter surface) ---
 
   createRoom(): void {
     this.sendEvent('createRoom', {})
@@ -460,16 +504,16 @@ export class GolfV2NetworkAdapter {
     this.sendEvent('leaveRoom', {})
   }
 
-  getRoomState(): void {
-    this.sendEvent('getRoomState', {})
-  }
-
-  sendChat(text: string): void {
-    this.sendEvent('chat', { text })
-  }
-
   createGame(_roomId: string): void {
-    this.pendingOwnCreates++
+    this.requestCreateGame()
+  }
+
+  startNewGame(): void {
+    // v2 folded startNewGame into createGame; the creator is auto-seated.
+    this.requestCreateGame()
+  }
+
+  private requestCreateGame(): void {
     this.sendMove('createGame')
   }
 
@@ -479,11 +523,6 @@ export class GolfV2NetworkAdapter {
 
   startGame(): void {
     this.sendMove('startGame')
-  }
-
-  startNewGame(): void {
-    // v2 folded startNewGame into createGame; the creator is auto-seated.
-    this.createGame('')
   }
 
   leaveGame(): void {
@@ -507,7 +546,7 @@ export class GolfV2NetworkAdapter {
     this._gameState = {
       ...this._gameState,
       drawnCard: view.discardTop,
-      discardPile: this._gameState.discardPile.slice(0, -1)
+      discardPile: []
     }
     this.callbacks.onGameStateUpdate?.(this._gameState)
   }
@@ -550,31 +589,5 @@ export class GolfV2NetworkAdapter {
   getCurrentPlayer(): Player | null {
     if (!this._gameState || !this._playerId) return null
     return this._gameState.players.find(p => p.id === this._playerId) ?? null
-  }
-
-  // --- resume token storage ---
-
-  private storeResumeToken(token: string): void {
-    try {
-      localStorage.setItem(RESUME_TOKEN_KEY, token)
-    } catch {
-      // Private mode: sessions just won't resume.
-    }
-  }
-
-  private getResumeToken(): string | null {
-    try {
-      return localStorage.getItem(RESUME_TOKEN_KEY)
-    } catch {
-      return null
-    }
-  }
-
-  private clearResumeToken(): void {
-    try {
-      localStorage.removeItem(RESUME_TOKEN_KEY)
-    } catch {
-      // Nothing to clear.
-    }
   }
 }

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -1,0 +1,580 @@
+/* eslint-disable no-console */
+// The golf v2 client (MoonBase#1187 phase 3): the smithy event-stream
+// wire, presented through the exact same adapter surface as the v1
+// GolfNetworkAdapter so useGolfGame and the components don't change.
+//
+// Wire shape (smithy-cpp ADR-0018 JSON-text mode):
+//   - POST /games/v2/session {resumeToken?} -> {playerId, ticket, resumeToken}
+//   - new WebSocket(playUrl + "?ticket=...", "smithy.eventstream.v1+json")
+//   - frames both ways: {"event": "<member>", "payload": {...}}
+//   - game moves ride the golf envelope: {"event":"golf","payload":{"move":{"drawCard":{}}}}
+//   - game updates arrive as {"event":"golf","payload":{"update":{"gameState":{...}}}}
+//
+// Two deliberate translations keep the v1 UI untouched:
+//   - v2 GameView -> v1 GameState (ids to indexes, slots to nullable
+//     cards, discard top+count to a pile array).
+//   - v1's take-then-place discard flow is emulated locally: the discard
+//     top is public, so "taking" it reveals nothing; the real v2
+//     takeFromDiscard{cardIndex} is sent when the player places it.
+
+import type { Card, GameState as GolfGameState, Player, Room, FinalScore } from '@/types/golf'
+import { golfV2PlayUrl, golfV2SessionUrl } from './golfV2'
+
+const RESUME_TOKEN_KEY = 'golf_v2_resume_token'
+const SUBPROTOCOL = 'smithy.eventstream.v1+json'
+const RECONNECT_DELAY_MS = 2000
+const MAX_RECONNECT_ATTEMPTS = 10
+
+// --- v2 wire shapes (mirrors model/games.smithy + model/golf_hub.smithy) ---
+
+interface V2CardSlot {
+  card?: Card
+}
+
+interface V2GamePlayer {
+  playerId: string
+  cards: V2CardSlot[]
+  revealedIndexes: number[]
+  hasPeeked: boolean
+  score?: number
+}
+
+interface V2GameView {
+  gameId: string
+  phase: 'waiting' | 'playing' | 'peeking' | 'knocked' | 'ended'
+  players: V2GamePlayer[]
+  currentPlayerId?: string
+  drawPileCount: number
+  discardCount: number
+  discardTop?: Card
+  drawnCard?: Card
+  knockedPlayerId?: string
+  allPlayersPeeked: boolean
+}
+
+interface V2PlayerInfo {
+  playerId: string
+  connected: boolean
+  gamesPlayed: number
+  gamesWon: number
+  totalScore: number
+}
+
+interface V2GameSummary {
+  gameId: string
+  status: string
+  playerCount: number
+}
+
+interface V2RoomState {
+  roomId: string
+  players: V2PlayerInfo[]
+  games: V2GameSummary[]
+}
+
+interface V2Events {
+  sessionReady?: { playerId: string; resumed: boolean; roomId?: string }
+  roomState?: V2RoomState
+  roomLeft?: { roomId: string }
+  roomChat?: { playerId: string; text: string }
+  commandRejected?: { reason: string }
+  golf?: { update: V2GolfUpdate }
+}
+
+interface V2GolfUpdate {
+  gameJoined?: { view: V2GameView }
+  gameState?: { view: V2GameView }
+  gameCreated?: { gameId: string }
+  gameStarted?: Record<string, never>
+  turnChanged?: { playerId: string }
+  playerKnocked?: { playerId: string }
+  gameEnded?: { winner: string; winners: string[]; finalScores: { playerId: string; score: number }[] }
+  gameLeft?: { gameId: string }
+}
+
+// --- v2 -> v1 shape translation ---
+
+function stubPlayer(id: string): Player {
+  return {
+    id,
+    name: id,
+    cards: [],
+    score: 0,
+    revealedCards: [],
+    isReady: false,
+    hasPeeked: false,
+    clientId: '',
+    totalScore: 0,
+    gamesPlayed: 0,
+    gamesWon: 0,
+    isConnected: true,
+    joinedAt: ''
+  }
+}
+
+function mapGamePlayer(player: V2GamePlayer): Player {
+  return {
+    ...stubPlayer(player.playerId),
+    cards: player.cards.map(slot => slot.card ?? null),
+    score: player.score ?? 0,
+    revealedCards: player.revealedIndexes,
+    hasPeeked: player.hasPeeked
+  }
+}
+
+function mapGameView(view: V2GameView): GolfGameState {
+  // The v1 shape carries the whole discard pile; v2 sends top + count.
+  // Only the top is ever rendered, so backfill with copies of the top.
+  const discardPile: Card[] =
+    view.discardTop == null ? [] : Array<Card>(view.discardCount).fill(view.discardTop)
+  const currentPlayerIndex = view.currentPlayerId
+    ? Math.max(0, view.players.findIndex(p => p.playerId === view.currentPlayerId))
+    : 0
+  return {
+    id: view.gameId,
+    players: view.players.map(mapGamePlayer),
+    currentPlayerIndex,
+    drawPile: view.drawPileCount,
+    discardPile,
+    gamePhase: view.phase,
+    knockedPlayerId: view.knockedPlayerId ?? null,
+    drawnCard: view.drawnCard ?? null,
+    allPlayersPeeked: view.allPlayersPeeked
+  }
+}
+
+function mapRoomState(room: V2RoomState): Room {
+  const games: Record<string, GolfGameState> = {}
+  for (const summary of room.games) {
+    games[summary.gameId] = {
+      id: summary.gameId,
+      players: Array.from({ length: summary.playerCount }, (_, i) => stubPlayer(`seat-${i}`)),
+      currentPlayerIndex: 0,
+      drawPile: 0,
+      discardPile: [],
+      gamePhase: summary.status as GolfGameState['gamePhase'],
+      knockedPlayerId: null,
+      drawnCard: null,
+      allPlayersPeeked: false
+    }
+  }
+  return {
+    id: room.roomId,
+    players: room.players.map(info => ({
+      ...stubPlayer(info.playerId),
+      isConnected: info.connected,
+      totalScore: info.totalScore,
+      gamesPlayed: info.gamesPlayed,
+      gamesWon: info.gamesWon
+    })),
+    games,
+    gameHistory: [],
+    createdAt: '',
+    lastActivity: ''
+  }
+}
+
+// --- the adapter ---
+
+export interface GolfAdapterCallbacks {
+  onRoomJoined?: (playerId: string, roomState: Room) => void
+  onGameJoined?: (playerId: string, gameState: GolfGameState) => void
+  onGameStateUpdate?: (gameState: GolfGameState) => void
+  onRoomStateUpdate?: (roomState: Room) => void
+  onNotification?: (message: string) => void
+  onConnectionChange?: (connected: boolean) => void
+  onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
+  onNewGameStarted?: (gameId: string, previousGameId?: string) => void
+  onReconnecting?: () => void
+  onGameError?: (message: string) => void
+}
+
+export class GolfV2NetworkAdapter {
+  private callbacks: GolfAdapterCallbacks
+  private ws: WebSocket | null = null
+  private _playerId: string | null = null
+  private _gameState: GolfGameState | null = null
+  private _roomState: Room | null = null
+  private closed = false
+  private reconnectAttempts = 0
+  private reconnectTimeout: number | null = null
+  private sawSessionReady = false
+
+  // The room the UI has been told it joined; the next different
+  // roomState fires onRoomJoined, same-room ones fire onRoomStateUpdate.
+  private announcedRoomId: string | null = null
+  // Our in-flight createGame requests: swallow their room-wide
+  // gameCreated echo (the creator is auto-seated and gets gameJoined).
+  private pendingOwnCreates = 0
+  // v1's take-then-place discard flow, emulated locally.
+  private pendingDiscardTake = false
+  private lastServerView: V2GameView | null = null
+
+  constructor(callbacks?: GolfAdapterCallbacks) {
+    this.callbacks = callbacks ?? {}
+  }
+
+  connect(_url?: string): void {
+    this.closed = false
+    void this.dial()
+  }
+
+  disconnect(): void {
+    this.closed = true
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout)
+      this.reconnectTimeout = null
+    }
+    this.ws?.close()
+    this.ws = null
+  }
+
+  get isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN
+  }
+
+  get playerId(): string | null {
+    return this._playerId
+  }
+
+  get gameState(): GolfGameState | null {
+    return this._gameState
+  }
+
+  get roomState(): Room | null {
+    return this._roomState
+  }
+
+  // --- session + socket lifecycle ---
+
+  private async dial(): Promise<void> {
+    try {
+      const stored = this.getResumeToken()
+      const response = await fetch(golfV2SessionUrl(), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(stored ? { resumeToken: stored } : {})
+      })
+      if (!response.ok) {
+        throw new Error(`session mint failed: ${response.status}`)
+      }
+      const session = (await response.json()) as {
+        playerId: string
+        ticket: string
+        resumeToken: string
+      }
+      this._playerId = session.playerId
+      this.storeResumeToken(session.resumeToken)
+
+      const url = `${golfV2PlayUrl()}?ticket=${encodeURIComponent(session.ticket)}`
+      const ws = new WebSocket(url, SUBPROTOCOL)
+      this.ws = ws
+      this.sawSessionReady = false
+
+      ws.onopen = () => {
+        console.log('🎮 golf v2 connected')
+        this.reconnectAttempts = 0
+        this.callbacks.onConnectionChange?.(true)
+      }
+      ws.onmessage = event => {
+        try {
+          this.handleFrame(JSON.parse(event.data as string) as { event?: string; payload?: unknown })
+        } catch (error) {
+          console.error('golf v2: bad frame', error)
+        }
+      }
+      ws.onclose = () => {
+        this.callbacks.onConnectionChange?.(false)
+        if (!this.sawSessionReady) {
+          // Refused before admission (spent ticket, seat conflict, bad
+          // resume token): drop the token so the next dial mints fresh.
+          this.clearResumeToken()
+        }
+        this.scheduleReconnect()
+      }
+      ws.onerror = () => {
+        // onclose follows; nothing useful in the browser error event.
+      }
+    } catch (error) {
+      console.error('golf v2: dial failed', error)
+      this.scheduleReconnect()
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed) return
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      this.callbacks.onGameError?.('Lost connection to the golf server')
+      return
+    }
+    this.reconnectAttempts++
+    console.log(`🔄 golf v2 reconnecting (${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`)
+    this.reconnectTimeout = window.setTimeout(() => void this.dial(), RECONNECT_DELAY_MS)
+  }
+
+  private sendEvent(event: string, payload: unknown): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      console.warn('golf v2: cannot send, not connected')
+      return
+    }
+    this.ws.send(JSON.stringify({ event, payload }))
+  }
+
+  private sendMove(move: string, payload: unknown = {}): void {
+    this.sendEvent('golf', { move: { [move]: payload } })
+  }
+
+  // --- inbound events ---
+
+  private handleFrame(frame: { event?: string; payload?: unknown }): void {
+    if (!frame.event) {
+      console.warn('golf v2: frame without event', frame)
+      return
+    }
+    const payload = (frame.payload ?? {}) as V2Events[keyof V2Events]
+    switch (frame.event as keyof V2Events) {
+      case 'sessionReady':
+        this.handleSessionReady(payload as NonNullable<V2Events['sessionReady']>)
+        return
+      case 'roomState':
+        this.handleRoomState(payload as V2RoomState)
+        return
+      case 'roomLeft':
+        this.announcedRoomId = null
+        this._roomState = null
+        return
+      case 'roomChat': {
+        const chat = payload as NonNullable<V2Events['roomChat']>
+        this.callbacks.onNotification?.(`${chat.playerId}: ${chat.text}`)
+        return
+      }
+      case 'commandRejected': {
+        const rejected = payload as NonNullable<V2Events['commandRejected']>
+        this.callbacks.onGameError?.(rejected.reason)
+        this.callbacks.onNotification?.(rejected.reason)
+        return
+      }
+      case 'golf':
+        this.handleUpdate((payload as NonNullable<V2Events['golf']>).update)
+        return
+      default:
+        console.warn(`golf v2: unknown event ${frame.event}`)
+    }
+  }
+
+  private handleSessionReady(ready: { playerId: string; resumed: boolean; roomId?: string }): void {
+    this._playerId = ready.playerId
+    this.sawSessionReady = true
+    if (ready.resumed && ready.roomId) {
+      console.log('♻️ golf v2 session resumed')
+      this.callbacks.onReconnecting?.()
+    }
+  }
+
+  private handleRoomState(room: V2RoomState): void {
+    const mapped = mapRoomState(room)
+    this._roomState = mapped
+    if (this.announcedRoomId !== room.roomId) {
+      this.announcedRoomId = room.roomId
+      this.callbacks.onRoomJoined?.(this._playerId ?? '', mapped)
+      this.callbacks.onNotification?.('Joined room successfully!')
+    } else {
+      this.callbacks.onRoomStateUpdate?.(mapped)
+    }
+  }
+
+  private handleUpdate(update: V2GolfUpdate): void {
+    if (update.gameJoined) {
+      this.acceptView(update.gameJoined.view)
+      this.callbacks.onGameJoined?.(this._playerId ?? '', this._gameState!)
+      this.callbacks.onNotification?.('Joined game successfully!')
+      return
+    }
+    if (update.gameState) {
+      this.acceptView(update.gameState.view)
+      this.callbacks.onGameStateUpdate?.(this._gameState!)
+      return
+    }
+    if (update.gameCreated) {
+      if (this.pendingOwnCreates > 0) {
+        // Our own create: the gameJoined we also receive carries the
+        // state, and announcing it would make the hook double-join.
+        this.pendingOwnCreates--
+        return
+      }
+      this.callbacks.onNotification?.('New game started!')
+      this.callbacks.onNewGameStarted?.(update.gameCreated.gameId)
+      return
+    }
+    if (update.gameStarted) {
+      this.callbacks.onNotification?.('Game started! Each player can peek at 2 cards.')
+      return
+    }
+    if (update.turnChanged) {
+      this.callbacks.onNotification?.(`It's ${update.turnChanged.playerId}'s turn`)
+      return
+    }
+    if (update.playerKnocked) {
+      this.callbacks.onNotification?.(`${update.playerKnocked.playerId} has knocked! Last round!`)
+      return
+    }
+    if (update.gameEnded) {
+      const ended = update.gameEnded
+      const finalScores: FinalScore[] = ended.finalScores.map(score => ({
+        playerName: score.playerId,
+        score: score.score
+      }))
+      this.callbacks.onNotification?.(`Game over! Winner: ${ended.winner}`)
+      this.callbacks.onGameEnded?.(ended.winner, finalScores, ended.winners)
+      return
+    }
+    if (update.gameLeft) {
+      this._gameState = null
+      this.lastServerView = null
+      this.pendingDiscardTake = false
+      return
+    }
+    console.warn('golf v2: unknown update', update)
+  }
+
+  private acceptView(view: V2GameView): void {
+    // Server state is authoritative: any update ends the local
+    // take-from-discard emulation.
+    this.lastServerView = view
+    this.pendingDiscardTake = false
+    this._gameState = mapGameView(view)
+  }
+
+  // --- actions (the v1 adapter surface) ---
+
+  createRoom(): void {
+    this.sendEvent('createRoom', {})
+  }
+
+  joinRoom(roomId: string): void {
+    this.sendEvent('joinRoom', { roomId })
+  }
+
+  leaveRoom(_roomId: string): void {
+    this.announcedRoomId = null
+    this.sendEvent('leaveRoom', {})
+  }
+
+  getRoomState(): void {
+    this.sendEvent('getRoomState', {})
+  }
+
+  sendChat(text: string): void {
+    this.sendEvent('chat', { text })
+  }
+
+  createGame(_roomId: string): void {
+    this.pendingOwnCreates++
+    this.sendMove('createGame')
+  }
+
+  joinGame(_roomId: string, gameId: string): void {
+    this.sendMove('joinGame', { gameId })
+  }
+
+  startGame(): void {
+    this.sendMove('startGame')
+  }
+
+  startNewGame(): void {
+    // v2 folded startNewGame into createGame; the creator is auto-seated.
+    this.createGame('')
+  }
+
+  leaveGame(): void {
+    this.sendMove('leaveGame')
+  }
+
+  peekCard(cardIndex: number): void {
+    this.sendMove('peekCard', { cardIndex })
+  }
+
+  drawCard(): void {
+    this.sendMove('drawCard')
+  }
+
+  takeFromDiscard(): void {
+    // The discard top is public: "picking it up" reveals nothing, so v1's
+    // hold step is purely local. The real move goes out on placement.
+    const view = this.lastServerView
+    if (!view || view.discardTop == null || this._gameState == null) return
+    this.pendingDiscardTake = true
+    this._gameState = {
+      ...this._gameState,
+      drawnCard: view.discardTop,
+      discardPile: this._gameState.discardPile.slice(0, -1)
+    }
+    this.callbacks.onGameStateUpdate?.(this._gameState)
+  }
+
+  swapCard(cardIndex: number): void {
+    if (this.pendingDiscardTake) {
+      this.pendingDiscardTake = false
+      this.sendMove('takeFromDiscard', { cardIndex })
+      return
+    }
+    this.sendMove('swapCard', { cardIndex })
+  }
+
+  discardDrawn(): void {
+    if (this.pendingDiscardTake) {
+      // Putting the discard top back: nothing ever left the server.
+      this.pendingDiscardTake = false
+      if (this.lastServerView) {
+        this._gameState = mapGameView(this.lastServerView)
+        this.callbacks.onGameStateUpdate?.(this._gameState)
+      }
+      return
+    }
+    this.sendMove('discardDrawn')
+  }
+
+  knock(): void {
+    this.sendMove('knock')
+  }
+
+  hideCards(): void {
+    this.sendMove('hideCards')
+  }
+
+  isMyTurn(): boolean {
+    if (!this._gameState || !this._playerId) return false
+    return this._gameState.players[this._gameState.currentPlayerIndex]?.id === this._playerId
+  }
+
+  getCurrentPlayer(): Player | null {
+    if (!this._gameState || !this._playerId) return null
+    return this._gameState.players.find(p => p.id === this._playerId) ?? null
+  }
+
+  // --- resume token storage ---
+
+  private storeResumeToken(token: string): void {
+    try {
+      localStorage.setItem(RESUME_TOKEN_KEY, token)
+    } catch {
+      // Private mode: sessions just won't resume.
+    }
+  }
+
+  private getResumeToken(): string | null {
+    try {
+      return localStorage.getItem(RESUME_TOKEN_KEY)
+    } catch {
+      return null
+    }
+  }
+
+  private clearResumeToken(): void {
+    try {
+      localStorage.removeItem(RESUME_TOKEN_KEY)
+    } catch {
+      // Nothing to clear.
+    }
+  }
+}

--- a/src/utils/networkAdapter.ts
+++ b/src/utils/networkAdapter.ts
@@ -3,7 +3,8 @@ import { NetworkManager } from './networkManager'
 import { ThoughtsNetworkPlugin } from '@/plugins/thoughtsNetworkPlugin'
 import { GolfNetworkPlugin } from '@/plugins/golfNetworkPlugin'
 import type { GameState } from '@/types/game'
-import type { GameState as GolfGameState, Room, FinalScore } from '@/types/golf'
+import type { GameState as GolfGameState, Room } from '@/types/golf'
+import type { GolfAdapterCallbacks, GolfGameAdapter } from '@/types/golfAdapter'
 import { ConnectionState, BaseNetworkMessage } from '@/types/network'
 
 // Factory function to create a network manager with pre-registered plugins
@@ -96,7 +97,7 @@ export class ThoughtsNetworkAdapter {
 }
 
 // Adapter for Golf game
-export class GolfNetworkAdapter {
+export class GolfNetworkAdapter implements GolfGameAdapter {
   private manager: NetworkManager
   private plugin: GolfNetworkPlugin
   private _playerId: string | null = null
@@ -104,18 +105,7 @@ export class GolfNetworkAdapter {
 
   private _roomState: Room | null = null
 
-  constructor(callbacks?: {
-    onRoomJoined?: (playerId: string, roomState: Room) => void
-    onGameJoined?: (playerId: string, gameState: GolfGameState) => void
-    onGameStateUpdate?: (gameState: GolfGameState) => void
-    onRoomStateUpdate?: (roomState: Room) => void
-    onNotification?: (message: string) => void
-    onConnectionChange?: (connected: boolean) => void
-    onGameEnded?: (winner: string, finalScores: FinalScore[], winners?: string[]) => void
-    onNewGameStarted?: (gameId: string, previousGameId?: string) => void
-    onReconnecting?: () => void
-    onGameError?: (message: string) => void
-  }) {
+  constructor(callbacks?: GolfAdapterCallbacks) {
     // Create manager with connection state callback
     this.manager = new NetworkManager({
       onConnectionStateChange: (state: ConnectionState) => {

--- a/src/utils/safeLocalStorage.ts
+++ b/src/utils/safeLocalStorage.ts
@@ -1,0 +1,26 @@
+// localStorage that shrugs instead of throwing — private mode and
+// storage-denied contexts make every direct call a potential exception.
+
+export const safeLocalStorage = {
+  get(key: string): string | null {
+    try {
+      return localStorage.getItem(key)
+    } catch {
+      return null
+    }
+  },
+  set(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value)
+    } catch {
+      // Not persisted; callers degrade gracefully.
+    }
+  },
+  remove(key: string): void {
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // Nothing to remove.
+    }
+  }
+}


### PR DESCRIPTION
Phase 3 of muchq/MoonBase#1187: the smithy hub's client, opt-in per browser.

## How it works

`GolfV2NetworkAdapter` presents the exact same surface as the v1 `GolfNetworkAdapter`, so `useGolfGame` changes by three lines (adapter selection) and no component changes at all. The adapter owns the v2 wire:

- `POST /games/v2/session` mints `{playerId, ticket, resumeToken}`; the resume token lives in localStorage and rides future mints so reconnects resume the same seat.
- The play socket dials with the ticket in the URL and the `smithy.eventstream.v1+json` subprotocol; frames are `{"event", "payload"}` envelopes, with game moves nested inside the `golf` member per the model.
- Reconnects re-mint with the resume token (2s backoff, 10 attempts, matching v1); a close before `sessionReady` means the ticket didn't spend or the seat is taken, so the token is dropped and the next dial mints fresh.

## The two translations

- **v2 views → v1 shapes.** `GameView` maps to the v1 `GameState` (player ids to indexes, card slots to nullable arrays, discard top+count to a pile array); `RoomState` maps to the v1 `Room` with stats and lobby game summaries. The whole hook/component layer renders unchanged.
- **Take-from-discard emulation.** v1 holds the discard top server-side before placing; v2 commits to a slot in one step. Since the discard top is public, the hold is emulated locally — clicking the discard shows it as held without sending anything, placement sends the real `takeFromDiscard{cardIndex}`, and putting it back silently restores the last server view. Any server update ends the emulation.

Also mapped: `gameCreated` → the v1 new-game notification (swallowed for your own creates, since v2 auto-seats the creator and `gameJoined` follows), `gameEnded` scores (`playerId` → `playerName`, `winners` passthrough for the shared-win celebration), `commandRejected` → in-band error, `roomChat` → notification.

## Opt-in

`?golf=v2` opts the browser in (sticky via localStorage), `?golf=v1` opts back out, `VITE_GOLF_V2_DEFAULT=true` flips a build. Default endpoints point at `wss://api.muchq.com/games/v2/golf/play`, overridable with `VITE_GOLF_V2_WEBSOCKET_URL`.

## Tests

16 new tests: session mint + ticket dial + subprotocol, resume-token round-trip and refusal handling, room announce-once semantics, view/room shape translation, the discard emulation (nothing sent on take, `takeFromDiscard{cardIndex}` on placement, silent put-back), own-create swallowing, gameEnded mapping, in-band rejection, envelope encoding for room commands and moves, and the beta switch's stickiness. Full suite: 238 passing; typecheck and lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_