### PR TITLE
golf: v2 beta toggle in the lobby, permalinks carry the flag

### DIFF
--- a/src/apps/golf/components/GolfGame.module.css
+++ b/src/apps/golf/components/GolfGame.module.css
@@ -1317,6 +1317,23 @@
   transform: translateY(-2px);
 }
 
+.betaToggle {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  font-family: 'Lexend', sans-serif;
+  cursor: pointer;
+  user-select: none;
+}
+
+.betaToggle input {
+  accent-color: #4ade80;
+}
+
 .rulesModal {
   position: fixed;
   top: 0;

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -4,6 +4,7 @@ import { useGolfGame } from '@/hooks/useGolfGame'
 import PermalinkDisplay from './PermalinkDisplay'
 import NewGameNotification from './NewGameNotification'
 import type { ParsedPermalinkParams } from '../../../utils/golfPermalinks'
+import { isGolfV2Enabled, setGolfV2Enabled } from '../../../utils/golfV2'
 
 interface Card {
   rank: string
@@ -28,6 +29,14 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
   const [showRules, setShowRules] = useState(false)
   const [showScores, setShowScores] = useState(false)
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
+  // Read once at mount: the active adapter was chosen from the same flag,
+  // and flipping it reloads so the choice and the connection can't skew.
+  const [v2Beta] = useState(() => isGolfV2Enabled())
+
+  const toggleV2Beta = () => {
+    setGolfV2Enabled(!v2Beta)
+    window.location.reload()
+  }
 
   // Helper function to get display name (now just use the ID directly)
   const getDisplayName = (player: Player | null) => {
@@ -160,6 +169,15 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
             >
               How to Play
             </button>
+
+            <label className={styles.betaToggle}>
+              <input
+                type="checkbox"
+                checked={v2Beta}
+                onChange={toggleV2Beta}
+              />
+              New engine beta
+            </label>
           </div>
         </div>
 

--- a/src/hooks/__tests__/useGolfGame.navigation.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.navigation.test.tsx
@@ -85,7 +85,7 @@ describe('useGolfGame navigation functionality', () => {
       
       expect(() => {
         act(() => {
-          result.current.navigateToRoom('invalid-room')
+          result.current.navigateToRoom('invalid room')
         })
       }).toThrow('Invalid room ID provided for permalink generation')
     })
@@ -95,7 +95,7 @@ describe('useGolfGame navigation functionality', () => {
       
       expect(() => {
         act(() => {
-          result.current.navigateToGame('room123', 'invalid-game')
+          result.current.navigateToGame('room123', 'invalid game')
         })
       }).toThrow('Invalid game ID provided for permalink generation')
     })

--- a/src/utils/__tests__/golfPermalinks.test.ts
+++ b/src/utils/__tests__/golfPermalinks.test.ts
@@ -18,9 +18,12 @@ describe('golfPermalinks', () => {
       expect(isValidId('Room1')).toBe(true)
     })
 
+    it('tolerates hyphens (hub session ids carry them)', () => {
+      expect(isValidId('abc-123')).toBe(true)
+    })
+
     it('should return false for invalid IDs', () => {
       expect(isValidId('')).toBe(false)
-      expect(isValidId('abc-123')).toBe(false)
       expect(isValidId('abc_123')).toBe(false)
       expect(isValidId('abc 123')).toBe(false)
       expect(isValidId('abc@123')).toBe(false)
@@ -63,7 +66,7 @@ describe('golfPermalinks', () => {
     })
 
     it('should return error for invalid room ID', () => {
-      const params: GolfRouteParams = { roomId: 'room-123' }
+      const params: GolfRouteParams = { roomId: 'room@123' }
       const result = parsePermalinkParams(params)
       expect(result).toEqual({
         roomId: null,
@@ -74,7 +77,7 @@ describe('golfPermalinks', () => {
     })
 
     it('should return error for invalid game ID', () => {
-      const params: GolfRouteParams = { roomId: 'room123', gameId: 'game-456' }
+      const params: GolfRouteParams = { roomId: 'room123', gameId: 'game@456' }
       const result = parsePermalinkParams(params)
       expect(result).toEqual({
         roomId: 'room123',
@@ -103,7 +106,13 @@ describe('golfPermalinks', () => {
     })
 
     it('should throw error for invalid room ID', () => {
-      expect(() => generateRoomPermalink('room-123')).toThrow('Invalid room ID provided for permalink generation')
+      expect(() => generateRoomPermalink('room 123')).toThrow('Invalid room ID provided for permalink generation')
+    })
+
+    it('carries the beta flag while v2 is enabled', () => {
+      localStorage.setItem('golf_v2_beta', '1')
+      expect(generateRoomPermalink('room123')).toBe('/golf/room/room123?golf=v2')
+      localStorage.clear()
     })
   })
 
@@ -114,11 +123,17 @@ describe('golfPermalinks', () => {
     })
 
     it('should throw error for invalid room ID', () => {
-      expect(() => generateGamePermalink('room-123', 'game456')).toThrow('Invalid room ID provided for permalink generation')
+      expect(() => generateGamePermalink('room 123', 'game456')).toThrow('Invalid room ID provided for permalink generation')
     })
 
     it('should throw error for invalid game ID', () => {
-      expect(() => generateGamePermalink('room123', 'game-456')).toThrow('Invalid game ID provided for permalink generation')
+      expect(() => generateGamePermalink('room123', 'game 456')).toThrow('Invalid game ID provided for permalink generation')
+    })
+
+    it('carries the beta flag while v2 is enabled', () => {
+      localStorage.setItem('golf_v2_beta', '1')
+      expect(generateGamePermalink('room123', 'game456')).toBe('/golf/room/room123/game/game456?golf=v2')
+      localStorage.clear()
     })
   })
 
@@ -191,7 +206,7 @@ describe('golfPermalinks', () => {
     })
 
     it('should validate extracted IDs', () => {
-      const result = extractIdsFromUrl('http://localhost:3000/golf/room/room-123')
+      const result = extractIdsFromUrl('http://localhost:3000/golf/room/room@123')
       expect(result).toEqual({
         roomId: null,
         gameId: null,

--- a/src/utils/__tests__/golfV2.test.ts
+++ b/src/utils/__tests__/golfV2.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { isGolfV2Enabled, golfV2SessionUrl } from '../golfV2'
+import { isGolfV2Enabled, setGolfV2Enabled, golfV2SessionUrl } from '../golfV2'
 
 describe('golf v2 beta switch', () => {
   const setSearch = (search: string) => {
@@ -33,6 +33,15 @@ describe('golf v2 beta switch', () => {
     expect(isGolfV2Enabled()).toBe(false)
 
     setSearch('')
+    expect(isGolfV2Enabled()).toBe(false)
+  })
+
+  it('the toggle setter persists an explicit choice both ways', () => {
+    setSearch('')
+    setGolfV2Enabled(true)
+    expect(isGolfV2Enabled()).toBe(true)
+
+    setGolfV2Enabled(false)
     expect(isGolfV2Enabled()).toBe(false)
   })
 

--- a/src/utils/golfPermalinks.ts
+++ b/src/utils/golfPermalinks.ts
@@ -2,6 +2,8 @@
  * Golf permalink utilities for URL parameter parsing and validation
  */
 
+import { isGolfV2Enabled } from './golfV2'
+
 export interface GolfRouteParams extends Record<string, string | undefined> {
   roomId?: string
   gameId?: string
@@ -15,13 +17,23 @@ export interface ParsedPermalinkParams {
 }
 
 /**
- * Validates if a room or game ID has the correct format
- * IDs should be alphanumeric strings
+ * Validates if a room or game ID has the correct format.
+ * Hub-minted ids are alphanumeric codes; hyphens are tolerated so an
+ * unexpected id shape degrades to an invalid-permalink message instead
+ * of a throw mid-render.
  */
 export function isValidId(id: string | undefined): boolean {
   if (!id) return false
-  // Check if ID is alphanumeric (letters and numbers only)
-  return /^[a-zA-Z0-9]+$/.test(id)
+  return /^[a-zA-Z0-9-]+$/.test(id)
+}
+
+/**
+ * While the v2 beta is active, minted permalinks carry the opt-in flag so
+ * a shared link lands its recipient on the same backend as its sender —
+ * a v2 room does not exist on the v1 hub.
+ */
+function betaSuffix(): string {
+  return isGolfV2Enabled() ? '?golf=v2' : ''
 }
 
 /**
@@ -84,7 +96,7 @@ export function generateRoomPermalink(roomId: string): string {
   if (!isValidId(roomId)) {
     throw new Error('Invalid room ID provided for permalink generation')
   }
-  return `/golf/room/${roomId}`
+  return `/golf/room/${roomId}${betaSuffix()}`
 }
 
 /**
@@ -97,7 +109,7 @@ export function generateGamePermalink(roomId: string, gameId: string): string {
   if (!isValidId(gameId)) {
     throw new Error('Invalid game ID provided for permalink generation')
   }
-  return `/golf/room/${roomId}/game/${gameId}`
+  return `/golf/room/${roomId}/game/${gameId}${betaSuffix()}`
 }
 
 /**

--- a/src/utils/golfV2.ts
+++ b/src/utils/golfV2.ts
@@ -26,6 +26,12 @@ export function isGolfV2Enabled(): boolean {
   return import.meta.env.VITE_GOLF_V2_DEFAULT === 'true'
 }
 
+// The lobby toggle's setter: an explicit choice, same persistence the
+// query param uses. Callers reload — the adapter is chosen at mount.
+export function setGolfV2Enabled(enabled: boolean): void {
+  safeLocalStorage.set(V2_FLAG_KEY, enabled ? '1' : '0')
+}
+
 export function golfV2PlayUrl(): string {
   return import.meta.env.VITE_GOLF_V2_WEBSOCKET_URL || 'wss://api.muchq.com/games/v2/golf/play'
 }


### PR DESCRIPTION
Prod-soak follow-ups on MoonBase#1187 phase 4:

- **Lobby toggle** ("New engine beta"): a visible switch over the same sticky localStorage flag `?golf=v2` sets. Flipping it reloads, since the adapter is chosen at mount — the checkbox and the live connection can never disagree.
- **Permalinks carry the flag**: while v2 is active, `generateRoomPermalink`/`generateGamePermalink` append `?golf=v2`, so a shared link lands its recipient on the same backend as its sender — a v2 room doesn't exist on the v1 hub. Navigation pushes the generated URL, so even a hand-copied address bar link carries it. (This is what a separate `/golf-beta` route would have bought, without duplicating routes or giving the sticky flag a second source of truth.)
- **Permalink validation tolerates hyphens**: current v2 room ids are hyphenated hex, and `generateRoomPermalink` threw mid-render on them. Hub-side short room codes are coming in MoonBase#1195; this makes the UI degrade to an invalid-permalink message rather than a throw whenever an id shape surprises it.

252 tests passing (new coverage for the setter, flagged permalinks, and hyphen tolerance), typecheck + lint clean.