### PR TITLE
golf: fix v2 toggle-off and URL-sync under the beta flag

### DIFF
--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -35,7 +35,11 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
 
   const toggleV2Beta = () => {
     setGolfV2Enabled(!v2Beta)
-    window.location.reload()
+    // Reload without any golf query param: the param outranks the stored
+    // choice on load, so keeping it would immediately undo the toggle.
+    const url = new URL(window.location.href)
+    url.searchParams.delete('golf')
+    window.location.href = url.toString()
   }
 
   // Helper function to get display name (now just use the ID directly)

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -752,10 +752,12 @@ export const useGolfGame = ({
       return
     }
 
+    // Compare path AND query: permalinks carry ?golf=v2 while the beta is
+    // active, and a pathname-only comparison would re-navigate every run.
     // If we have both room and game state, ensure URL reflects game
     if (roomState && gameState && roomState.id && gameState.id) {
       const expectedUrl = generateGamePermalink(roomState.id, gameState.id)
-      const currentPath = window.location.pathname
+      const currentPath = window.location.pathname + window.location.search
       if (currentPath !== expectedUrl) {
         navigate(expectedUrl, { replace: true })
       }
@@ -763,7 +765,7 @@ export const useGolfGame = ({
     // If we only have room state, ensure URL reflects room
     else if (roomState && roomState.id && !gameState) {
       const expectedUrl = generateRoomPermalink(roomState.id)
-      const currentPath = window.location.pathname
+      const currentPath = window.location.pathname + window.location.search
       if (currentPath !== expectedUrl && !currentPath.includes('/game/')) {
         navigate(expectedUrl, { replace: true })
       }

--- a/src/utils/__tests__/golfPermalinks.test.ts
+++ b/src/utils/__tests__/golfPermalinks.test.ts
@@ -72,7 +72,7 @@ describe('golfPermalinks', () => {
         roomId: null,
         gameId: null,
         isValid: false,
-        error: 'Invalid room ID format. Room IDs must be alphanumeric.'
+        error: 'Invalid room ID format. Room IDs may contain only letters, numbers, and hyphens.'
       })
     })
 
@@ -83,7 +83,7 @@ describe('golfPermalinks', () => {
         roomId: 'room123',
         gameId: null,
         isValid: false,
-        error: 'Invalid game ID format. Game IDs must be alphanumeric.'
+        error: 'Invalid game ID format. Game IDs may contain only letters, numbers, and hyphens.'
       })
     })
 
@@ -114,6 +114,11 @@ describe('golfPermalinks', () => {
       expect(generateRoomPermalink('room123')).toBe('/golf/room/room123?golf=v2')
       localStorage.clear()
     })
+
+    it('omits the beta flag while v2 is disabled', () => {
+      localStorage.clear()
+      expect(generateRoomPermalink('room123')).toBe('/golf/room/room123')
+    })
   })
 
   describe('generateGamePermalink', () => {
@@ -134,6 +139,11 @@ describe('golfPermalinks', () => {
       localStorage.setItem('golf_v2_beta', '1')
       expect(generateGamePermalink('room123', 'game456')).toBe('/golf/room/room123/game/game456?golf=v2')
       localStorage.clear()
+    })
+
+    it('omits the beta flag while v2 is disabled', () => {
+      localStorage.clear()
+      expect(generateGamePermalink('room123', 'game456')).toBe('/golf/room/room123/game/game456')
     })
   })
 
@@ -211,7 +221,7 @@ describe('golfPermalinks', () => {
         roomId: null,
         gameId: null,
         isValid: false,
-        error: 'Invalid room ID format. Room IDs must be alphanumeric.'
+        error: 'Invalid room ID format. Room IDs may contain only letters, numbers, and hyphens.'
       })
     })
   })

--- a/src/utils/golfPermalinks.ts
+++ b/src/utils/golfPermalinks.ts
@@ -30,7 +30,9 @@ export function isValidId(id: string | undefined): boolean {
 /**
  * While the v2 beta is active, minted permalinks carry the opt-in flag so
  * a shared link lands its recipient on the same backend as its sender —
- * a v2 room does not exist on the v1 hub.
+ * a v2 room does not exist on the v1 hub. Deliberately applied on every
+ * generated path, not just explicit share links: navigation pushes these
+ * into the address bar, and a hand-copied URL must carry the flag too.
  */
 function betaSuffix(): string {
   return isGolfV2Enabled() ? '?golf=v2' : ''
@@ -58,7 +60,7 @@ export function parsePermalinkParams(params: GolfRouteParams): ParsedPermalinkPa
       roomId: null,
       gameId: null,
       isValid: false,
-      error: 'Invalid room ID format. Room IDs must be alphanumeric.'
+      error: 'Invalid room ID format. Room IDs may contain only letters, numbers, and hyphens.'
     }
   }
   
@@ -68,7 +70,7 @@ export function parsePermalinkParams(params: GolfRouteParams): ParsedPermalinkPa
       roomId: roomId || null,
       gameId: null,
       isValid: false,
-      error: 'Invalid game ID format. Game IDs must be alphanumeric.'
+      error: 'Invalid game ID format. Game IDs may contain only letters, numbers, and hyphens.'
     }
   }
   


### PR DESCRIPTION
Panel follow-up on #233 — two real bugs the review panel's correctness lens caught, plus polish:

- **Toggle couldn't turn v2 off with `?golf=v2` in the URL.** `window.location.reload()` kept the query param, which outranks the stored choice on load, so unchecking the box immediately re-enabled the beta (reachable via a dead room permalink: the failed join leaves `?golf=v2` in the address bar while showing the lobby). The toggle now reloads with the `golf` param stripped, so the just-persisted choice wins in both directions.
- **URL-sync effect defeated while v2 is active.** It compared `window.location.pathname` against permalinks that now carry `?golf=v2`, so the "already at the target URL" guard never matched and every room/game state change issued a redundant history replace. It compares path+query now.
- Id-validation error copy updated to match the hyphen tolerance ("may contain only letters, numbers, and hyphens"), explicit flag-off permalink tests so the v1 shape is pinned deliberately rather than by ambient default, and the `betaSuffix` comment now states why it applies to every generated path (address-bar copies must carry the flag).

254 tests, typecheck + lint clean.