### PR TITLE
Metrics overhaul: host page + catalog-driven service pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
       <Route path="/tracy" element={<TracyPage />} />
       <Route path="/posterize" element={<PosterizePage />} />
       <Route path="/wordchains" element={<WordchainsPage />} />
-      <Route path="/metrics" element={<Navigate to="/metrics/system" replace />} />
+      <Route path="/metrics" element={<Navigate to="/metrics/host" replace />} />
       <Route path="/metrics/:tab" element={<MetricsPage />} />
       <Route path="/resilience" element={<SystemsPage />} />
       <Route path="/resilience/phase1/level1" element={<ResilienceGamePage />} />

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -1,0 +1,90 @@
+// Types and helpers for the prom_proxy dashboard API (MoonBase#1199):
+// the service catalog, the merged host payload, and the generic
+// per-service standard + custom blocks.
+
+export const METRICS_API_URL =
+  import.meta.env.VITE_METRICS_API_URL || 'https://api.muchq.com/metrics/v1'
+
+export interface ServiceCatalogEntry {
+  name: string
+  has_custom: boolean
+}
+
+export interface ServiceCatalog {
+  services: ServiceCatalogEntry[]
+}
+
+export interface StandardMetrics {
+  requests_total: number
+  rate_per_sec: number
+  success_count_5m: number
+  failure_count_5m: number
+  error_rate_percent: number
+  avg_duration_microseconds: number
+  p95_duration_microseconds: number
+  active_requests: number
+}
+
+export interface CustomMetricValue {
+  label: string
+  value: number
+  unit: string
+}
+
+export interface CustomMetricGroup {
+  title: string
+  metrics: CustomMetricValue[]
+}
+
+export interface ServiceMetricsResponse {
+  timestamp: string
+  service: string
+  standard: StandardMetrics
+  custom: CustomMetricGroup[]
+}
+
+export interface TimeSeries {
+  metric_name: string
+  labels?: Record<string, string>
+  values: Array<{
+    timestamp: string
+    value: number
+  }>
+}
+
+export interface TimeSeriesResponse {
+  time_range: string
+  start_time: string
+  end_time: string
+  step: string
+  series: TimeSeries[]
+}
+
+// null on any failure — sections render their no-data state instead of
+// tearing the page down.
+export async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) return null
+    const text = await response.text()
+    if (!text.trim()) return null
+    return JSON.parse(text) as T
+  } catch {
+    return null
+  }
+}
+
+const DISPLAY_NAMES: Record<string, string> = {
+  golf_hub: 'Golf Hub',
+  'microgpt-serve': 'MicroGPT',
+  portrait: 'Portrait',
+}
+
+// Catalog names the registry hasn't special-cased render title-cased.
+export function serviceDisplayName(name: string): string {
+  if (DISPLAY_NAMES[name]) return DISPLAY_NAMES[name]
+  return name
+    .split(/[-_]/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -139,6 +139,11 @@
   letter-spacing: -0.3px;
 }
 
+.miniUnit {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 /* Main Metrics Grid */
 .metricsGrid {
   max-width: 1400px;

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -64,27 +64,14 @@ interface ContainerMetrics {
   containers: ContainerStats[]
 }
 
-interface MicrogptScalar {
+interface HostMetricsResponse {
   timestamp: string
-  requests: {
-    rate_per_sec: number
-    generate_total: number
-    chat_total: number
-    success_count_5m: number
-    failure_count_5m: number
-  }
-  inference: {
-    tokens_generated_total: number
-    tokens_per_second_avg: number
-    avg_duration_ms: number
-    conversation_total: number
-  }
+  system: SystemMetrics | null
+  containers: ContainerStats[]
 }
 
 interface MetricsDashboardProps {
   onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
-  activeTab?: 'system' | 'containers' | 'portrait' | 'microgpt'
-  onTabChange?: (tab: 'system' | 'containers' | 'portrait' | 'microgpt') => void
 }
 
 const formatBytes = (bytes: number) => {
@@ -148,14 +135,11 @@ const MemoryTooltip = ({ active, payload }: { active?: boolean; payload?: Array<
   return null
 }
 
-const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTabChange }: MetricsDashboardProps) => {
+const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) => {
   const [systemMetrics, setSystemMetrics] = useState<SystemMetrics | null>(null)
   const [systemTimeseries, setSystemTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [containerMetrics, setContainerMetrics] = useState<ContainerMetrics | null>(null)
   const [containerTimeseries, setContainerTimeseries] = useState<TimeSeriesResponse | null>(null)
-  const [portraitTimeseries, setPortraitTimeseries] = useState<TimeSeriesResponse | null>(null)
-  const [microgptScalar, setMicrogptScalar] = useState<MicrogptScalar | null>(null)
-  const [microgptTimeseries, setMicrogptTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
 
@@ -167,96 +151,39 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
       // Use environment variable for API URL, defaulting to production URL
       const apiUrl = import.meta.env.VITE_METRICS_API_URL || 'https://api.muchq.com/metrics/v1'
 
-      // Fetch current system metrics
+      // The merged host endpoint (#1199): system + per-container scalars in
+      // one payload, container series namespaced container_* in the other.
       try {
-        const systemResponse = await fetch(`${apiUrl}/scalar/system`)
-        if (systemResponse.ok) {
-          const text = await systemResponse.text()
+        const hostResponse = await fetch(`${apiUrl}/host`)
+        if (hostResponse.ok) {
+          const text = await hostResponse.text()
           if (text.trim()) {
-            const systemData = JSON.parse(text)
-            setSystemMetrics(systemData)
+            const hostData: HostMetricsResponse = JSON.parse(text)
+            if (hostData.system) setSystemMetrics(hostData.system)
+            setContainerMetrics({ timestamp: hostData.timestamp, containers: hostData.containers || [] })
           }
         }
       } catch {
         // Silently handle error - UI will show "no data" state
       }
 
-      // Fetch system timeseries
       try {
-        const systemTimeseriesResponse = await fetch(`${apiUrl}/timeseries/system/${timeRange}`)
-        if (systemTimeseriesResponse.ok) {
-          const text = await systemTimeseriesResponse.text()
+        const hostTimeseriesResponse = await fetch(`${apiUrl}/host/timeseries/${timeRange}`)
+        if (hostTimeseriesResponse.ok) {
+          const text = await hostTimeseriesResponse.text()
           if (text.trim()) {
-            const systemTimeseriesData = JSON.parse(text)
-            setSystemTimeseries(systemTimeseriesData)
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
-      }
-
-      // Fetch container metrics
-      try {
-        const containerResponse = await fetch(`${apiUrl}/scalar/containers`)
-        if (containerResponse.ok) {
-          const text = await containerResponse.text()
-          if (text.trim()) {
-            const containerData = JSON.parse(text)
-            setContainerMetrics(containerData)
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
-      }
-
-      // Fetch container timeseries
-      try {
-        const containerTimeseriesResponse = await fetch(`${apiUrl}/timeseries/containers/${timeRange}`)
-        if (containerTimeseriesResponse.ok) {
-          const text = await containerTimeseriesResponse.text()
-          if (text.trim()) {
-            const containerTimeseriesData = JSON.parse(text)
-            setContainerTimeseries(containerTimeseriesData)
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
-      }
-
-      // Fetch portrait timeseries
-      try {
-        const portraitTimeseriesResponse = await fetch(`${apiUrl}/timeseries/portrait/${timeRange}`)
-        if (portraitTimeseriesResponse.ok) {
-          const text = await portraitTimeseriesResponse.text()
-          if (text.trim()) {
-            const portraitTimeseriesData = JSON.parse(text)
-            setPortraitTimeseries(portraitTimeseriesData)
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
-      }
-
-      // Fetch microgpt scalar
-      try {
-        const microgptScalarResponse = await fetch(`${apiUrl}/scalar/microgpt`)
-        if (microgptScalarResponse.ok) {
-          const text = await microgptScalarResponse.text()
-          if (text.trim()) {
-            setMicrogptScalar(JSON.parse(text))
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
-      }
-
-      // Fetch microgpt timeseries
-      try {
-        const microgptTimeseriesResponse = await fetch(`${apiUrl}/timeseries/microgpt/${timeRange}`)
-        if (microgptTimeseriesResponse.ok) {
-          const text = await microgptTimeseriesResponse.text()
-          if (text.trim()) {
-            setMicrogptTimeseries(JSON.parse(text))
+            const merged: TimeSeriesResponse = JSON.parse(text)
+            const hostSeries: TimeSeries[] = []
+            const containerSeries: TimeSeries[] = []
+            for (const series of merged.series || []) {
+              if (series.metric_name.startsWith('container_')) {
+                containerSeries.push({ ...series, metric_name: series.metric_name.slice('container_'.length) })
+              } else {
+                hostSeries.push(series)
+              }
+            }
+            setSystemTimeseries({ ...merged, series: hostSeries })
+            setContainerTimeseries({ ...merged, series: containerSeries })
           }
         }
       } catch {
@@ -394,64 +321,7 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
     }))
   }
 
-  const getPortraitMetricsData = () => {
-    if (!portraitTimeseries?.series) return []
 
-    // Get success rate data
-    const successSeries = portraitTimeseries.series.find(s => s.metric_name === 'request_success_rate')
-    const cacheSeries = portraitTimeseries.series.find(s => s.metric_name === 'cache_hit_rate')
-    const durationSeries = portraitTimeseries.series.find(s => s.metric_name === 'request_duration_avg')
-
-    if (!successSeries?.values?.length) return []
-
-    return successSeries.values.map((v, i) => ({
-      time: formatTimestamp(v.timestamp),
-      successRate: Math.max(0, Math.min(100, v.value || 0)),
-      cacheHitRate: cacheSeries && i < cacheSeries.values.length ? Math.max(0, Math.min(100, cacheSeries.values[i].value || 0)) : 0,
-      avgDuration: durationSeries && i < durationSeries.values.length ? (durationSeries.values[i].value || 0) / 1000 : 0 // Convert to ms
-    }))
-  }
-
-
-  const getCacheOperationsData = () => {
-    if (!portraitTimeseries?.series) return []
-
-    const cacheOpsSeries = portraitTimeseries.series.find(s => s.metric_name === 'cache_operations_rate')
-    if (!cacheOpsSeries?.values?.length) return []
-
-    return cacheOpsSeries.values.map(v => ({
-      time: formatTimestamp(v.timestamp),
-      operations: v.value || 0
-    }))
-  }
-
-  const getSceneComplexityData = () => {
-    if (!portraitTimeseries?.series) return []
-
-    const sphereSeries = portraitTimeseries.series.find(s => s.metric_name === 'scene_sphere_count')
-    const lightSeries = portraitTimeseries.series.find(s => s.metric_name === 'scene_light_count')
-
-    if (!sphereSeries?.values?.length) return []
-
-    return sphereSeries.values.map((v, i) => ({
-      time: formatTimestamp(v.timestamp),
-      spheres: v.value || 0,
-      lights: lightSeries && i < lightSeries.values.length ? (lightSeries.values[i].value || 0) : 0
-    }))
-  }
-
-
-  const getCacheHitRateData = () => {
-    if (!portraitTimeseries?.series) return []
-
-    const cacheSeries = portraitTimeseries.series.find(s => s.metric_name === 'cache_hit_rate')
-    if (!cacheSeries?.values?.length) return []
-
-    return cacheSeries.values.map(v => ({
-      time: formatTimestamp(v.timestamp),
-      hitRate: Math.max(0, Math.min(100, v.value || 0))
-    }))
-  }
 
   const generateFullTimeRange = () => {
     const now = new Date()
@@ -508,31 +378,6 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
     })
   }
 
-  const fillTimeSeriesData = (series: TimeSeries | undefined, defaultValue: number = 0) => {
-    const dataMap = new Map()
-
-    if (series?.values?.length) {
-      series.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        dataMap.set(key, { count: Math.max(0, v.value || 0) })
-      })
-    }
-
-    return fillTimeSeriesWithRange(dataMap, { count: defaultValue })
-  }
-
-  const getRequestSuccessCountData = () => {
-    const successSeries = portraitTimeseries?.series?.find(s => s.metric_name === 'request_success_count')
-    return fillTimeSeriesData(successSeries, 0)
-  }
-
-  const getRequestFailureCountData = () => {
-    const failureSeries = portraitTimeseries?.series?.find(s => s.metric_name === 'request_failure_count')
-    return fillTimeSeriesData(failureSeries, 0)
-  }
-
   const COLORS = {
     primary: '#66b6ff',
     success: '#66ff66',
@@ -543,9 +388,9 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
   }
 
   return (
-    <div className={styles.dashboard}>
+    <div>
       <div className={styles.header}>
-        <h1 className={styles.title}>Metrics Dashboard</h1>
+        <h1 className={styles.title}>Host Metrics</h1>
         <div className={styles.controls}>
           <select
             value={timeRange}
@@ -564,37 +409,9 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
         </div>
       </div>
 
-      {/* Tab Navigation */}
-      <div className={styles.tabNavigation}>
-        <button
-          className={`${styles.tab} ${activeTab === 'system' ? styles.activeTab : ''}`}
-          onClick={() => onTabChange?.('system')}
-        >
-          System Metrics
-        </button>
-        <button
-          className={`${styles.tab} ${activeTab === 'containers' ? styles.activeTab : ''}`}
-          onClick={() => onTabChange?.('containers')}
-        >
-          Container Metrics
-        </button>
-        <button
-          className={`${styles.tab} ${activeTab === 'portrait' ? styles.activeTab : ''}`}
-          onClick={() => onTabChange?.('portrait')}
-        >
-          Portrait Metrics
-        </button>
-        <button
-          className={`${styles.tab} ${activeTab === 'microgpt' ? styles.activeTab : ''}`}
-          onClick={() => onTabChange?.('microgpt')}
-        >
-          MicroGPT Metrics
-        </button>
-      </div>
-
       {/* Tab Content */}
       <div className={styles.metricsGrid}>
-        {activeTab === 'system' && (
+        {(
           <>
             {/* System Overview Cards */}
             {systemMetrics && (
@@ -820,7 +637,7 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
           </>
         )}
 
-        {activeTab === 'containers' && (
+        {(
           <>
             {/* Container Overview Cards */}
             {containerMetrics && containerMetrics.containers.length > 0 && (
@@ -1131,372 +948,6 @@ const MetricsDashboard = ({ onConnectionStateChange, activeTab = 'system', onTab
                 </div>
               </div>
             </div>
-          </>
-        )}
-
-        {activeTab === 'microgpt' && (
-          <>
-            {/* Overview cards */}
-            {microgptScalar && (
-              <div className={styles.overviewCards}>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Req/s</div>
-                  <div className={styles.miniValue}>{(microgptScalar.requests.rate_per_sec || 0).toFixed(2)}</div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Tokens/s</div>
-                  <div className={styles.miniValue}>{(microgptScalar.inference.tokens_per_second_avg || 0).toFixed(1)}</div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Chats</div>
-                  <div className={styles.miniValue}>{(microgptScalar.inference.conversation_total || 0).toFixed(0)}</div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Avg ms</div>
-                  <div className={styles.miniValue}>{(microgptScalar.inference.avg_duration_ms || 0).toFixed(0)}</div>
-                </div>
-              </div>
-            )}
-
-            {/* Inference Activity */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Inference Activity</h2>
-              <div className={styles.sectionGrid}>
-                {/* Tokens per Second */}
-                <div className={styles.compactChart}>
-                  <h4>Tokens / Second</h4>
-                  {(() => {
-                    const series = microgptTimeseries?.series?.find(s => s.metric_name === 'tokens_per_second')
-                    if (!series?.values?.length) return <NoDataMessage />
-                    const data = series.values.map(v => ({ time: formatTimestamp(v.timestamp), value: Math.max(0, v.value || 0) }))
-                    return (
-                      <ChartErrorBoundary>
-                        <ResponsiveContainer width="100%" height={180}>
-                          <AreaChart data={data}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                            <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                            <YAxis stroke="#888" fontSize={10} />
-                            <Tooltip
-                              contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                              formatter={(value) => [`${Number(value).toFixed(1)} tok/s`, 'Tokens/s']}
-                            />
-                            <Area type="monotone" dataKey="value" stroke={COLORS.info} fill="rgba(255, 102, 255, 0.3)" strokeWidth={2} />
-                          </AreaChart>
-                        </ResponsiveContainer>
-                      </ChartErrorBoundary>
-                    )
-                  })()}
-                </div>
-
-                {/* Request Rate */}
-                <div className={styles.compactChart}>
-                  <h4>Request Rate</h4>
-                  {(() => {
-                    const series = microgptTimeseries?.series?.find(s => s.metric_name === 'request_rate')
-                    if (!series?.values?.length) return <NoDataMessage />
-                    const data = series.values.map(v => ({ time: formatTimestamp(v.timestamp), value: Math.max(0, v.value || 0) }))
-                    return (
-                      <ChartErrorBoundary>
-                        <ResponsiveContainer width="100%" height={180}>
-                          <LineChart data={data}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                            <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                            <YAxis stroke="#888" fontSize={10} />
-                            <Tooltip
-                              contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 182, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                              formatter={(value) => [`${Number(value).toFixed(3)} req/s`, 'Request Rate']}
-                            />
-                            <Line type="monotone" dataKey="value" stroke={COLORS.primary} strokeWidth={2} dot={false} />
-                          </LineChart>
-                        </ResponsiveContainer>
-                      </ChartErrorBoundary>
-                    )
-                  })()}
-                </div>
-
-                {/* Average Request Duration */}
-                <div className={styles.compactChart}>
-                  <h4>Avg Request Duration</h4>
-                  {(() => {
-                    const series = microgptTimeseries?.series?.find(s => s.metric_name === 'request_duration_ms')
-                    if (!series?.values?.length) return <NoDataMessage />
-                    const data = series.values.map(v => ({ time: formatTimestamp(v.timestamp), value: Math.max(0, v.value || 0) }))
-                    return (
-                      <ChartErrorBoundary>
-                        <ResponsiveContainer width="100%" height={180}>
-                          <AreaChart data={data}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                            <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                            <YAxis stroke="#888" fontSize={10} tickFormatter={(v) => `${v.toFixed(0)}ms`} />
-                            <Tooltip
-                              contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 204, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                              formatter={(value) => [`${Number(value).toFixed(0)} ms`, 'Avg Duration']}
-                            />
-                            <Area type="monotone" dataKey="value" stroke={COLORS.warning} fill="rgba(255, 204, 102, 0.3)" strokeWidth={2} />
-                          </AreaChart>
-                        </ResponsiveContainer>
-                      </ChartErrorBoundary>
-                    )
-                  })()}
-                </div>
-
-                {/* Conversation Rate */}
-                <div className={styles.compactChart}>
-                  <h4>Chat Conversation Rate</h4>
-                  {(() => {
-                    const series = microgptTimeseries?.series?.find(s => s.metric_name === 'conversation_rate')
-                    if (!series?.values?.length) return <NoDataMessage />
-                    const data = series.values.map(v => ({ time: formatTimestamp(v.timestamp), value: Math.max(0, v.value || 0) }))
-                    return (
-                      <ChartErrorBoundary>
-                        <ResponsiveContainer width="100%" height={180}>
-                          <LineChart data={data}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                            <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                            <YAxis stroke="#888" fontSize={10} />
-                            <Tooltip
-                              contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                              formatter={(value) => [`${Number(value).toFixed(3)} conv/s`, 'Conversation Rate']}
-                            />
-                            <Line type="monotone" dataKey="value" stroke={COLORS.success} strokeWidth={2} dot={false} />
-                          </LineChart>
-                        </ResponsiveContainer>
-                      </ChartErrorBoundary>
-                    )
-                  })()}
-                </div>
-              </div>
-            </div>
-
-            {/* Health */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Service Health</h2>
-              <div className={styles.sectionGrid}>
-                {/* Success Count */}
-                <div className={styles.compactChart}>
-                  <h4>Success Count (5m windows)</h4>
-                  <ChartErrorBoundary>
-                    <ResponsiveContainer width="100%" height={180}>
-                      <BarChart data={fillTimeSeriesData(microgptTimeseries?.series?.find(s => s.metric_name === 'success_count'), 0)}>
-                        <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                        <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                        <YAxis stroke="#888" fontSize={10} />
-                        <Tooltip
-                          contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                          formatter={(value) => [`${Number(value).toFixed(0)}`, 'Successes']}
-                        />
-                        <Bar dataKey="count" fill={COLORS.success} />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </ChartErrorBoundary>
-                </div>
-
-                {/* Failure Count */}
-                <div className={styles.compactChart}>
-                  <h4>Failure Count (5m windows)</h4>
-                  <ChartErrorBoundary>
-                    <ResponsiveContainer width="100%" height={180}>
-                      <BarChart data={fillTimeSeriesData(microgptTimeseries?.series?.find(s => s.metric_name === 'failure_count'), 0)}>
-                        <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                        <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                        <YAxis stroke="#888" fontSize={10} />
-                        <Tooltip
-                          contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                          formatter={(value) => [`${Number(value).toFixed(0)}`, 'Failures']}
-                        />
-                        <Bar dataKey="count" fill={COLORS.danger} />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </ChartErrorBoundary>
-                </div>
-
-                {/* Endpoint breakdown (current totals) */}
-                {microgptScalar && (
-                  <div className={styles.compactChart}>
-                    <h4>Endpoint Totals</h4>
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={[
-                          { name: 'Generate', total: microgptScalar.requests.generate_total || 0 },
-                          { name: 'Chat', total: microgptScalar.requests.chat_total || 0 },
-                        ]}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} />
-                          <YAxis stroke="#888" fontSize={10} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 182, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(0)}`, 'Requests']}
-                          />
-                          <Bar dataKey="total" fill={COLORS.primary} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  </div>
-                )}
-              </div>
-            </div>
-          </>
-        )}
-
-        {activeTab === 'portrait' && (
-          <>
-        {/* Request Performance Section */}
-        <div className={styles.section}>
-          <h2 className={styles.sectionTitle}>Request Performance</h2>
-          <div className={styles.sectionGrid}>
-            {/* Request Success Count */}
-            <div className={styles.compactChart}>
-              <h4>Request Success Count</h4>
-              <ChartErrorBoundary>
-                <ResponsiveContainer width="100%" height={180}>
-                  <BarChart data={getRequestSuccessCountData()}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                    <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                    <YAxis stroke="#888" fontSize={10} />
-                    <Tooltip
-                      contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                      formatter={(value) => [`${Number(value).toFixed(0)}`, 'Success Count']}
-                    />
-                    <Bar dataKey="count" fill={COLORS.success} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </ChartErrorBoundary>
-            </div>
-
-            {/* Request Error Count */}
-            <div className={styles.compactChart}>
-              <h4>Request Error Count</h4>
-              <ChartErrorBoundary>
-                <ResponsiveContainer width="100%" height={180}>
-                  <BarChart data={getRequestFailureCountData()}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                    <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                    <YAxis stroke="#888" fontSize={10} />
-                    <Tooltip
-                      contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                      formatter={(value) => [`${Number(value).toFixed(0)}`, 'Error Count']}
-                    />
-                    <Bar dataKey="count" fill={COLORS.danger} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </ChartErrorBoundary>
-            </div>
-
-            {/* Combined Portrait Metrics */}
-            <div className={styles.compactChart}>
-              <h4>Combined Portrait Metrics</h4>
-              {getPortraitMetricsData().length > 0 ? (
-                <ChartErrorBoundary>
-                  <ResponsiveContainer width="100%" height={180}>
-                    <LineChart data={getPortraitMetricsData()}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                      <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                      <YAxis stroke="#888" fontSize={10} />
-                      <Tooltip
-                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                        formatter={(value, name) => [
-                          name === 'avgDuration' ? `${Number(value).toFixed(2)}ms` : `${Number(value).toFixed(1)}%`,
-                          name === 'successRate' ? 'Success Rate' : name === 'cacheHitRate' ? 'Cache Hit Rate' : 'Avg Duration'
-                        ]}
-                      />
-                      <Line type="monotone" dataKey="successRate" stroke={COLORS.success} strokeWidth={2} dot={false} />
-                      <Line type="monotone" dataKey="cacheHitRate" stroke={COLORS.primary} strokeWidth={2} dot={false} />
-                      <Line type="monotone" dataKey="avgDuration" stroke={COLORS.warning} strokeWidth={2} dot={false} yAxisId="right" />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </ChartErrorBoundary>
-              ) : (
-                <NoDataMessage />
-              )}
-            </div>
-
-          </div>
-        </div>
-
-        {/* Cache Performance Section */}
-        <div className={styles.section}>
-          <h2 className={styles.sectionTitle}>Cache Performance</h2>
-          <div className={styles.sectionGrid}>
-            {/* Cache Hit Rate */}
-            <div className={styles.compactChart}>
-              <h4>Cache Hit Rate</h4>
-              {getCacheHitRateData().length > 0 ? (
-                <ChartErrorBoundary>
-                  <ResponsiveContainer width="100%" height={180}>
-                    <AreaChart data={getCacheHitRateData()}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                      <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                      <YAxis stroke="#888" fontSize={10} domain={[0, 100]} tickFormatter={(value) => `${value}%`} />
-                      <Tooltip
-                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 182, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                        formatter={(value) => [`${Number(value).toFixed(1)}%`, 'Hit Rate']}
-                      />
-                      <Area type="monotone" dataKey="hitRate" stroke={COLORS.primary} fill="rgba(102, 182, 255, 0.3)" strokeWidth={2} />
-                    </AreaChart>
-                  </ResponsiveContainer>
-                </ChartErrorBoundary>
-              ) : (
-                <NoDataMessage />
-              )}
-            </div>
-
-            {/* Cache Operations Rate */}
-            <div className={styles.compactChart}>
-              <h4>Cache Operations Rate</h4>
-              {getCacheOperationsData().length > 0 ? (
-                <ChartErrorBoundary>
-                  <ResponsiveContainer width="100%" height={180}>
-                    <BarChart data={getCacheOperationsData()}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                      <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}/s`} />
-                      <Tooltip
-                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                        formatter={(value) => [`${Number(value).toFixed(2)}/s`, 'Operations']}
-                      />
-                      <Bar dataKey="operations" fill={COLORS.info} />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </ChartErrorBoundary>
-              ) : (
-                <NoDataMessage />
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Scene Complexity Section */}
-        <div className={styles.section}>
-          <h2 className={styles.sectionTitle}>Scene Complexity</h2>
-          <div className={styles.sectionGrid}>
-            {/* Scene Elements */}
-            <div className={styles.compactChart}>
-              <h4>Scene Elements</h4>
-              {getSceneComplexityData().length > 0 ? (
-                <ChartErrorBoundary>
-                  <ResponsiveContainer width="100%" height={180}>
-                    <LineChart data={getSceneComplexityData()}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                      <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                      <YAxis stroke="#888" fontSize={10} />
-                      <Tooltip
-                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                        formatter={(value, name) => [
-                          `${Number(value).toFixed(0)}`,
-                          name === 'spheres' ? 'Spheres' : 'Lights'
-                        ]}
-                      />
-                      <Line type="monotone" dataKey="spheres" stroke={COLORS.danger} strokeWidth={2} dot={false} />
-                      <Line type="monotone" dataKey="lights" stroke={COLORS.warning} strokeWidth={2} dot={false} />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </ChartErrorBoundary>
-              ) : (
-                <NoDataMessage />
-              )}
-            </div>
-          </div>
-        </div>
           </>
         )}
       </div>

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -1,0 +1,252 @@
+import { useState, useEffect, useCallback } from 'react'
+import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import ChartErrorBoundary from './ChartErrorBoundary'
+import styles from './MetricsDashboard.module.css'
+import {
+  METRICS_API_URL,
+  fetchJson,
+  serviceDisplayName,
+  type ServiceMetricsResponse,
+  type TimeSeries,
+  type TimeSeriesResponse,
+} from '../api'
+
+interface ServiceDashboardProps {
+  service: string
+  onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
+}
+
+// The five series every service page charts; anything else in the
+// timeseries payload is a custom series and renders generically below.
+const STANDARD_SERIES = new Set([
+  'request_rate',
+  'error_rate_percent',
+  'avg_duration_us',
+  'p95_duration_us',
+  'active_requests',
+])
+
+const formatValue = (value: number) => {
+  const magnitude = Math.abs(value)
+  if (magnitude >= 1000) return Math.round(value).toLocaleString()
+  if (magnitude >= 100) return value.toFixed(0)
+  if (magnitude >= 10) return value.toFixed(1)
+  return value.toFixed(2)
+}
+
+const prettyLabel = (label: string) =>
+  label.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+
+const NoDataMessage = () => <div className={styles.noData}>No data available</div>
+
+const SeriesChart = ({
+  title,
+  series,
+  color,
+  unit,
+  area = false,
+  scale = (value: number) => value,
+}: {
+  title: string
+  series: TimeSeries | undefined
+  color: string
+  unit: string
+  area?: boolean
+  scale?: (value: number) => number
+}) => {
+  const formatTimestamp = (timestamp: string) =>
+    new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+  return (
+    <div className={styles.compactChart}>
+      <h4>{title}</h4>
+      {series?.values?.length ? (
+        <ChartErrorBoundary>
+          <ResponsiveContainer width="100%" height={180}>
+            {area ? (
+              <AreaChart data={series.values.map((v) => ({ time: formatTimestamp(v.timestamp), value: scale(Math.max(0, v.value || 0)) }))}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
+                <YAxis stroke="#888" fontSize={10} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                  formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
+                />
+                <Area type="monotone" dataKey="value" stroke={color} fill={`${color}44`} strokeWidth={2} />
+              </AreaChart>
+            ) : (
+              <LineChart data={series.values.map((v) => ({ time: formatTimestamp(v.timestamp), value: scale(Math.max(0, v.value || 0)) }))}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
+                <YAxis stroke="#888" fontSize={10} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                  formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
+                />
+                <Line type="monotone" dataKey="value" stroke={color} strokeWidth={2} dot={false} />
+              </LineChart>
+            )}
+          </ResponsiveContainer>
+        </ChartErrorBoundary>
+      ) : (
+        <NoDataMessage />
+      )}
+    </div>
+  )
+}
+
+const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboardProps) => {
+  const [scalar, setScalar] = useState<ServiceMetricsResponse | null>(null)
+  const [timeseries, setTimeseries] = useState<TimeSeriesResponse | null>(null)
+  const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
+  const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+  const [lastService, setLastService] = useState(service)
+
+  // Tab switches drop the previous service's data during render, so a
+  // slow fetch can't flash stale numbers under the new title.
+  if (service !== lastService) {
+    setLastService(service)
+    setScalar(null)
+    setTimeseries(null)
+  }
+
+  const fetchMetrics = useCallback(async () => {
+    setTimeout(() => onConnectionStateChange('connecting'), 0)
+
+    const [scalarData, seriesData] = await Promise.all([
+      fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}`),
+      fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
+    ])
+    if (scalarData) setScalar(scalarData)
+    if (seriesData) setTimeseries(seriesData)
+
+    if (scalarData || seriesData) {
+      setLastUpdate(new Date())
+      onConnectionStateChange('connected')
+    } else {
+      onConnectionStateChange('failed')
+    }
+  }, [service, timeRange, onConnectionStateChange])
+
+  useEffect(() => {
+    setTimeout(fetchMetrics, 0)
+    const interval = setInterval(fetchMetrics, 30000)
+    return () => clearInterval(interval)
+  }, [fetchMetrics])
+
+  const findSeries = (name: string) => timeseries?.series?.find((s) => s.metric_name === name)
+  const customSeries = (timeseries?.series ?? []).filter((s) => !STANDARD_SERIES.has(s.metric_name))
+  const standard = scalar?.standard
+
+  const COLORS = {
+    primary: '#66b6ff',
+    success: '#66ff88',
+    warning: '#ffaa44',
+    danger: '#ff6666',
+    info: '#ff66ff',
+  }
+
+  return (
+    <div>
+      <div className={styles.header}>
+        <h1 className={styles.title}>{serviceDisplayName(service)}</h1>
+        <div className={styles.controls}>
+          <select
+            value={timeRange}
+            onChange={(e) => setTimeRange(e.target.value as '30m' | '1d' | '7d')}
+            className={styles.timeRangeSelect}
+          >
+            <option value="30m">30m</option>
+            <option value="1d">1d</option>
+            <option value="7d">7d</option>
+          </select>
+          {lastUpdate && (
+            <span className={styles.lastUpdate}>
+              {lastUpdate.toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.metricsGrid}>
+        {/* The standard serving block, identical for every service. */}
+        {standard && (
+          <div className={styles.overviewCards}>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>Req/s</div>
+              <div className={styles.miniValue}>{(standard.rate_per_sec || 0).toFixed(2)}</div>
+            </div>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>Error %</div>
+              <div className={styles.miniValue}>{(standard.error_rate_percent || 0).toFixed(1)}</div>
+            </div>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>Avg ms</div>
+              <div className={styles.miniValue}>{((standard.avg_duration_microseconds || 0) / 1000).toFixed(1)}</div>
+            </div>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>P95 ms</div>
+              <div className={styles.miniValue}>{((standard.p95_duration_microseconds || 0) / 1000).toFixed(1)}</div>
+            </div>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>Active</div>
+              <div className={styles.miniValue}>{(standard.active_requests || 0).toFixed(0)}</div>
+            </div>
+            <div className={styles.miniCard}>
+              <div className={styles.miniLabel}>Total</div>
+              <div className={styles.miniValue}>{formatValue(standard.requests_total || 0)}</div>
+            </div>
+          </div>
+        )}
+
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Serving</h2>
+          <div className={styles.sectionGrid}>
+            <SeriesChart title="Request Rate" series={findSeries('request_rate')} color={COLORS.primary} unit="req/s" />
+            <SeriesChart title="Error Rate" series={findSeries('error_rate_percent')} color={COLORS.danger} unit="%" />
+            <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area />
+            <SeriesChart title="Active Requests" series={findSeries('active_requests')} color={COLORS.success} unit="" area />
+          </div>
+        </div>
+
+        {/* Custom scalar groups, rendered from the API's descriptors. */}
+        {scalar?.custom?.map((group) => (
+          <div className={styles.section} key={group.title}>
+            <h2 className={styles.sectionTitle}>{group.title}</h2>
+            <div className={styles.overviewCards}>
+              {group.metrics.map((metric) => (
+                <div className={styles.miniCard} key={metric.label}>
+                  <div className={styles.miniLabel}>{prettyLabel(metric.label)}</div>
+                  <div className={styles.miniValue}>
+                    {formatValue(metric.value || 0)}
+                    {metric.unit && <span className={styles.miniUnit}> {metric.unit}</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Every non-standard series charts generically. */}
+        {customSeries.length > 0 && (
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>Trends</h2>
+            <div className={styles.sectionGrid}>
+              {customSeries.map((series, index) => (
+                <SeriesChart
+                  key={series.metric_name}
+                  title={prettyLabel(series.metric_name)}
+                  series={series}
+                  color={[COLORS.primary, COLORS.info, COLORS.success, COLORS.warning][index % 4]}
+                  unit=""
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ServiceDashboard

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act } from '@testing-library/react'
+import { render, act, screen } from '@testing-library/react'
 import MetricsDashboard from '../MetricsDashboard'
 
 // Mock the recharts library to avoid canvas issues in tests
@@ -13,384 +13,114 @@ vi.mock('recharts', () => ({
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
   Tooltip: () => <div data-testid="tooltip" />,
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
-  BarChart: ({ children, data }: { children: React.ReactNode; data: unknown }) => <div data-testid="bar-chart" data-chart-data={JSON.stringify(data)}>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
   Bar: () => <div data-testid="bar" />,
   PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
   Pie: () => <div data-testid="pie" />,
   Cell: () => <div data-testid="cell" />
 }))
 
-// Generate mock data with recent timestamps to match the component's time range generation
-const generateMockTimestamps = () => {
-  const now = new Date()
-  const timestamps = []
-
-  // Generate timestamps for the last 30 minutes with 30-second intervals
-  for (let i = 59; i >= 0; i--) {
-    const time = new Date(now.getTime() - i * 30 * 1000)
-    timestamps.push(time.toISOString())
-  }
-
-  return timestamps
+const hostResponse = {
+  timestamp: new Date().toISOString(),
+  system: {
+    timestamp: new Date().toISOString(),
+    cpu: { utilization_percent: 42.5, by_core: { '0': 40.1 } },
+    memory: {
+      total_bytes: 12884901888,
+      used_bytes: 6442450944,
+      free_bytes: 4294967296,
+      cached_bytes: 2147483648,
+      utilization_percent: 50.0,
+    },
+    disk: [],
+    network: [],
+  },
+  containers: [
+    {
+      name: 'caddy',
+      cpu_usage_percent: 5.5,
+      cpu_throttled_seconds: 0,
+      memory_usage_bytes: 1048576,
+      memory_limit_bytes: 268435456,
+      memory_usage_percent: 0.4,
+      network_rx_bytes_per_sec: 0,
+      network_tx_bytes_per_sec: 0,
+    },
+  ],
 }
 
-const mockTimestamps = generateMockTimestamps()
-const now = new Date()
-const startTime = new Date(now.getTime() - 30 * 60 * 1000).toISOString()
-const endTime = now.toISOString()
-
-const mockPortraitTimeseriesResponse = {
-  "time_range": "30m",
-  "start_time": startTime,
-  "end_time": endTime,
-  "step": "30s",
-  "series": [
+const hostTimeseriesResponse = {
+  time_range: '1d',
+  start_time: new Date(Date.now() - 86400000).toISOString(),
+  end_time: new Date().toISOString(),
+  step: '30s',
+  series: [
     {
-      "metric_name": "request_duration_avg",
-      "labels": {
-        "cache_hit": "false",
-        "exported_job": "portrait",
-        "instance": "otelcol:8889",
-        "job": "otel-collector",
-        "otel_scope_name": "portrait",
-        "otel_scope_version": "1.0.0"
-      },
-      "values": [
-        {"timestamp": mockTimestamps[0], "value": 0},
-        {"timestamp": mockTimestamps[1], "value": 0},
-        {"timestamp": mockTimestamps[2], "value": 0},
-        {"timestamp": mockTimestamps[20], "value": 193682.00000000003},
-        {"timestamp": mockTimestamps[21], "value": 189137},
-        {"timestamp": mockTimestamps[22], "value": 189137}
-      ]
+      metric_name: 'cpu_utilization',
+      values: [{ timestamp: new Date().toISOString(), value: 40.0 }],
     },
     {
-      "metric_name": "request_success_count",
-      "labels": {
-        "exported_job": "portrait",
-        "instance": "otelcol:8889",
-        "job": "otel-collector",
-        "method": "POST",
-        "otel_scope_name": "portrait",
-        "otel_scope_version": "1.0.0",
-        "route": "/v1/trace",
-        "service_name": "portrait"
-      },
-      "values": [
-        {"timestamp": mockTimestamps[40], "value": 15.653199999999998},
-        {"timestamp": mockTimestamps[41], "value": 21.445471513643234},
-        {"timestamp": mockTimestamps[42], "value": 26.10855565777369},
-        {"timestamp": mockTimestamps[43], "value": 26.54054782108266},
-        {"timestamp": mockTimestamps[44], "value": 25.975985718835883},
-        {"timestamp": mockTimestamps[45], "value": 43.761892758974625},
-        {"timestamp": mockTimestamps[46], "value": 44.39376864853265},
-        {"timestamp": mockTimestamps[47], "value": 44.075359999999996},
-        {"timestamp": mockTimestamps[48], "value": 43.8312},
-        {"timestamp": mockTimestamps[49], "value": 44.21006094672688},
-        {"timestamp": mockTimestamps[50], "value": 25.263157894736842},
-        {"timestamp": mockTimestamps[51], "value": 25.263246537707154},
-        {"timestamp": mockTimestamps[52], "value": 18.947634352762847},
-        {"timestamp": mockTimestamps[53], "value": 18.94736842105263},
-        {"timestamp": mockTimestamps[54], "value": 26.315420134454254},
-        {"timestamp": mockTimestamps[55], "value": 21.052336107563402},
-        {"timestamp": mockTimestamps[56], "value": 21.052631578947366},
-        {"timestamp": mockTimestamps[57], "value": 22.105263157894736},
-        {"timestamp": mockTimestamps[58], "value": 25.263512470350463},
-        {"timestamp": mockTimestamps[59], "value": 25.263157894736842}
-      ]
+      metric_name: 'container_cpu_usage',
+      labels: { name: 'caddy' },
+      values: [{ timestamp: new Date().toISOString(), value: 5.0 }],
     },
-    {
-      "metric_name": "request_failure_count",
-      "labels": {
-        "error_type": "rate_limited",
-        "exported_job": "portrait",
-        "instance": "otelcol:8889",
-        "job": "otel-collector",
-        "method": "POST",
-        "otel_scope_name": "portrait",
-        "otel_scope_version": "1.0.0",
-        "result": "failure",
-        "route": "/v1/trace",
-        "service_name": "portrait",
-        "status_code": "429"
-      },
-      "values": [
-        {"timestamp": "2025-09-15T03:23:14Z", "value": 0},
-        {"timestamp": "2025-09-15T03:23:44Z", "value": 2.4939892896029154},
-        {"timestamp": "2025-09-15T03:24:14Z", "value": 2.2963961441542335},
-        {"timestamp": "2025-09-15T03:24:44Z", "value": 2.211712318423555},
-        {"timestamp": "2025-09-15T03:25:14Z", "value": 2.164665476569657},
-        {"timestamp": "2025-09-15T03:25:44Z", "value": 2.13471408957579},
-        {"timestamp": "2025-09-15T03:26:14Z", "value": 2.1140307692307694},
-        {"timestamp": "2025-09-15T03:26:44Z", "value": 2.0988266666666666},
-        {"timestamp": "2025-09-15T03:27:14Z", "value": 2.0871761370281456},
-        {"timestamp": "2025-09-15T03:27:44Z", "value": 2.1052631578947367},
-        {"timestamp": "2025-09-15T03:28:14Z", "value": 2.1052705448089295},
-        {"timestamp": "2025-09-15T03:28:44Z", "value": 0},
-        {"timestamp": "2025-09-15T03:29:14Z", "value": 0},
-        {"timestamp": "2025-09-15T03:29:44Z", "value": 5.2630840268908505},
-        {"timestamp": "2025-09-15T03:30:14Z", "value": 6.315700832269021},
-        {"timestamp": "2025-09-15T03:30:44Z", "value": 8.421052631578947},
-        {"timestamp": "2025-09-15T03:31:14Z", "value": 8.421052631578947},
-        {"timestamp": "2025-09-15T03:31:44Z", "value": 8.421170823450154},
-        {"timestamp": "2025-09-15T03:32:14Z", "value": 8.421052631578947},
-        {"timestamp": "2025-09-15T03:32:44Z", "value": 8.420934443025361},
-        {"timestamp": "2025-09-15T03:33:14Z", "value": 8.421141275171317}
-      ]
-    }
-  ]
+  ],
 }
 
-interface TimeSeries {
-  metric_name: string
-  labels?: Record<string, string>
-  values: Array<{
-    timestamp: string
-    value: number
-  }>
-}
-
-describe('MetricsDashboard fillTimeSeriesData logic', () => {
-  let mockFetch: typeof fetch
+describe('MetricsDashboard (host view)', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    // Mock fetch to return our test data
-    mockFetch = vi.fn()
-    globalThis.fetch = mockFetch
-
-    // Setup default mock responses
-    ;(mockFetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
-      if (url.includes('/v1/timeseries/portrait/')) {
-        return Promise.resolve({
-          ok: true,
-          text: () => Promise.resolve(JSON.stringify(mockPortraitTimeseriesResponse))
-        })
+    mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/host/timeseries/')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(hostTimeseriesResponse)) })
       }
-      return Promise.resolve({
-        ok: false,
-        text: () => Promise.resolve('')
-      })
+      if (url.endsWith('/host')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(hostResponse)) })
+      }
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
     })
+    globalThis.fetch = mockFetch as unknown as typeof fetch
   })
 
-  it('should extract and fill time series data correctly for success counts', async () => {
+  it('renders host scalars and the container table from the merged endpoint', async () => {
     const onConnectionStateChange = vi.fn()
-    const { container } = render(
-      <MetricsDashboard
-        onConnectionStateChange={onConnectionStateChange}
-        activeTab="portrait"
-      />
-    )
+    render(<MetricsDashboard onConnectionStateChange={onConnectionStateChange} />)
 
-    // Wait for the component to fetch data and render
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
-    // Find the success count chart
-    const successChart = container.querySelector('[data-testid="bar-chart"]')
-    expect(successChart).toBeTruthy()
-
-    // Extract the chart data
-    const chartDataAttr = successChart?.getAttribute('data-chart-data')
-    if (chartDataAttr) {
-      const chartData = JSON.parse(chartDataAttr) as Array<{ time: string; count: number }>
-
-      // The chart should have data points
-      expect(chartData).toBeInstanceOf(Array)
-      expect(chartData.length).toBeGreaterThan(0)
-
-      // Check that we have some data points with actual values (not all zeros)
-      const hasNonZeroValues = chartData.some((point) => point.count > 0)
-      expect(hasNonZeroValues).toBe(true)
-
-      // Verify the data structure
-      chartData.forEach((point) => {
-        expect(point).toHaveProperty('time')
-        expect(point).toHaveProperty('count')
-        expect(typeof point.time).toBe('string')
-        expect(typeof point.count).toBe('number')
-        expect(point.count).toBeGreaterThanOrEqual(0)
-      })
-    }
+    expect(screen.getByText('Host Metrics')).toBeTruthy()
+    expect(screen.getByText('42.5%')).toBeTruthy()
+    expect(screen.getAllByText('caddy').length).toBeGreaterThan(0)
+    expect(onConnectionStateChange).toHaveBeenCalledWith('connected')
   })
 
-  it('should demonstrate the broken state with exact timestamp matching', () => {
-    // This test demonstrates the issue with the original broken implementation
-    const brokenFillTimeSeriesData = (series: TimeSeries, defaultValue: number = 0) => {
-      const fullTimeRange = generateTestTimeRange()
+  it('fetches only the merged host endpoints', async () => {
+    render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
 
-      if (!series?.values?.length) {
-        return fullTimeRange.map(point => ({
-          time: point.time,
-          count: defaultValue
-        }))
-      }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
 
-      // Create a map of existing data points - THIS IS BROKEN
-      const dataMap = new Map<string, number>()
-      series.values.forEach((v) => {
-        const timestamp = new Date(v.timestamp).toISOString()
-        dataMap.set(timestamp, v.value || 0)
-      })
-
-      // Fill the full time range, using actual data where available
-      return fullTimeRange.map(point => ({
-        time: point.time,
-        count: Math.max(0, dataMap.get(point.timestamp) || defaultValue)
-      }))
-    }
-
-    const generateTestTimeRange = () => {
-      // Generate timestamps that are slightly different from the API timestamps to simulate the issue
-      const now = new Date('2025-09-15T03:33:14.123Z') // Slightly different milliseconds
-      const points = []
-      for (let i = 59; i >= 0; i--) {
-        const time = new Date(now.getTime() - i * 30 * 1000) // 30-second intervals
-        points.push({
-          time: time.toLocaleTimeString(),
-          timestamp: time.toISOString()
-        })
-      }
-      return points
-    }
-
-    const testSeries = mockPortraitTimeseriesResponse.series[1] as unknown as TimeSeries // Use success count series
-    const result = brokenFillTimeSeriesData(testSeries, 0)
-
-    // With the broken implementation, all values should be 0 because timestamps don't match exactly
-    // (API timestamps vs generated timestamps have different milliseconds/precision)
-    const allZeros = result.every(point => point.count === 0)
-    expect(allZeros).toBe(true)
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((url) => url.endsWith('/host'))).toBe(true)
+    expect(urls.some((url) => url.includes('/host/timeseries/'))).toBe(true)
+    expect(urls.some((url) => url.includes('/scalar/'))).toBe(false)
+    expect(urls.some((url) => url.includes('/timeseries/system'))).toBe(false)
   })
 
-  it('should fix the issue with rounded timestamp matching using fillTimeSeriesWithRange', () => {
-    // This test demonstrates the new fillTimeSeriesWithRange utility
-    const fillTimeSeriesWithRange = <T extends Record<string, number | string>>(
-      seriesMap: Map<string, Partial<T>>,
-      defaultValues: T,
-      fullTimeRange: Array<{ time: string; timestamp: string }>
-    ): Array<T & { time: string }> => {
-      return fullTimeRange.map(point => {
-        const pointTime = new Date(point.timestamp)
-        const roundedPointTime = new Date(Math.round(pointTime.getTime() / 30000) * 30000)
-        const key = roundedPointTime.toISOString()
+  it('stays up with empty sections when the API is down', async () => {
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, text: () => Promise.resolve('') }))
+    const onConnectionStateChange = vi.fn()
+    render(<MetricsDashboard onConnectionStateChange={onConnectionStateChange} />)
 
-        const dataPoint = seriesMap.get(key)
-        return {
-          time: point.time,
-          ...defaultValues,
-          ...(dataPoint || {})
-        } as T & { time: string }
-      })
-    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
 
-    const generateTestTimeRange = () => {
-      // Generate timestamps that are slightly different from the API timestamps
-      const now = new Date() // Use current time to match mock data
-      const points = []
-      for (let i = 59; i >= 0; i--) {
-        const time = new Date(now.getTime() - i * 30 * 1000) // 30-second intervals
-        points.push({
-          time: time.toLocaleTimeString(),
-          timestamp: time.toISOString()
-        })
-      }
-      return points
-    }
-
-    const testSeries = mockPortraitTimeseriesResponse.series[1] as unknown as TimeSeries // Use success count series
-    const dataMap = new Map()
-
-    if (testSeries?.values?.length) {
-      testSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        dataMap.set(key, { count: Math.max(0, v.value || 0) })
-      })
-    }
-
-    const fullTimeRange = generateTestTimeRange()
-    const result = fillTimeSeriesWithRange(dataMap, { count: 0 }, fullTimeRange)
-
-    // With the fixed implementation, we should have some non-zero values
-    const hasNonZeroValues = result.some(point => point.count > 0)
-    expect(hasNonZeroValues).toBe(true)
-
-    // Verify that we captured the expected values
-    const nonZeroPoints = result.filter(point => point.count > 0)
-    expect(nonZeroPoints.length).toBeGreaterThan(0)
-
-    // Check that the values match what we expect from the test data (use some of the actual values from our mock)
-    const expectedValues = [15.653199999999998, 21.445471513643234, 26.10855565777369, 43.761892758974625, 25.263157894736842]
-    const hasExpectedValue = nonZeroPoints.some(point =>
-      expectedValues.some(expectedValue => Math.abs(point.count - expectedValue) < 0.001)
-    )
-    expect(hasExpectedValue).toBe(true)
-  })
-
-  it('should handle multi-field data with fillTimeSeriesWithRange', () => {
-    // Test the utility with multiple fields (like rx/tx for network data)
-    const fillTimeSeriesWithRange = <T extends Record<string, number | string>>(
-      seriesMap: Map<string, Partial<T>>,
-      defaultValues: T,
-      fullTimeRange: Array<{ time: string; timestamp: string }>
-    ): Array<T & { time: string }> => {
-      return fullTimeRange.map(point => {
-        const pointTime = new Date(point.timestamp)
-        const roundedPointTime = new Date(Math.round(pointTime.getTime() / 30000) * 30000)
-        const key = roundedPointTime.toISOString()
-
-        const dataPoint = seriesMap.get(key)
-        return {
-          time: point.time,
-          ...defaultValues,
-          ...(dataPoint || {})
-        } as T & { time: string }
-      })
-    }
-
-    const generateTestTimeRange = () => {
-      const now = new Date()
-      const points = []
-      for (let i = 9; i >= 0; i--) {
-        const time = new Date(now.getTime() - i * 30 * 1000)
-        points.push({
-          time: time.toLocaleTimeString(),
-          timestamp: time.toISOString()
-        })
-      }
-      return points
-    }
-
-    const dataMap = new Map()
-    const fullTimeRange = generateTestTimeRange()
-
-    // Simulate network data with both rx and tx values
-    const timestamp1 = new Date(fullTimeRange[5].timestamp)
-    const rounded1 = new Date(Math.round(timestamp1.getTime() / 30000) * 30000)
-    dataMap.set(rounded1.toISOString(), { rx: 100, tx: 50 })
-
-    const timestamp2 = new Date(fullTimeRange[7].timestamp)
-    const rounded2 = new Date(Math.round(timestamp2.getTime() / 30000) * 30000)
-    dataMap.set(rounded2.toISOString(), { rx: 200, tx: 75 })
-
-    const result = fillTimeSeriesWithRange(dataMap, { rx: 0, tx: 0 }, fullTimeRange)
-
-    // Should have 10 data points (full time range)
-    expect(result.length).toBe(10)
-
-    // Points without data should have default values
-    expect(result[0]).toEqual({ time: result[0].time, rx: 0, tx: 0 })
-
-    // Points with data should have the actual values
-    const pointWithData1 = result[5]
-    expect(pointWithData1.rx).toBe(100)
-    expect(pointWithData1.tx).toBe(50)
-
-    const pointWithData2 = result[7]
-    expect(pointWithData2.rx).toBe(200)
-    expect(pointWithData2.tx).toBe(75)
+    expect(screen.getByText('Host Metrics')).toBeTruthy()
+    expect(screen.queryByText('caddy')).toBeNull()
   })
 })

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act, screen } from '@testing-library/react'
+import ServiceDashboard from '../ServiceDashboard'
+
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div data-testid="line" />,
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+}))
+
+const scalarResponse = {
+  timestamp: new Date().toISOString(),
+  service: 'golf_hub',
+  standard: {
+    requests_total: 1234,
+    rate_per_sec: 1.25,
+    success_count_5m: 100,
+    failure_count_5m: 5,
+    error_rate_percent: 4.8,
+    avg_duration_microseconds: 1500,
+    p95_duration_microseconds: 9500,
+    active_requests: 2,
+  },
+  custom: [
+    { title: 'Sessions', metrics: [{ label: 'active', value: 3, unit: 'sessions' }] },
+    { title: 'Activity', metrics: [{ label: 'commands_per_sec', value: 0.5, unit: '/s' }] },
+  ],
+}
+
+const timeseriesResponse = {
+  time_range: '1d',
+  start_time: new Date(Date.now() - 86400000).toISOString(),
+  end_time: new Date().toISOString(),
+  step: '30s',
+  series: [
+    { metric_name: 'request_rate', values: [{ timestamp: new Date().toISOString(), value: 1.2 }] },
+    { metric_name: 'sessions_active', values: [{ timestamp: new Date().toISOString(), value: 3 }] },
+  ],
+}
+
+describe('ServiceDashboard', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(timeseriesResponse)) })
+      }
+      if (url.endsWith('/service/golf_hub')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(scalarResponse)) })
+      }
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+    globalThis.fetch = mockFetch as unknown as typeof fetch
+  })
+
+  it('renders the standard block above custom groups', async () => {
+    const onConnectionStateChange = vi.fn()
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={onConnectionStateChange} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Golf Hub')).toBeTruthy()
+    // Standard tiles: rate, error %, avg/p95 converted to ms, active, total.
+    expect(screen.getByText('1.25')).toBeTruthy()
+    expect(screen.getByText('4.8')).toBeTruthy()
+    expect(screen.getByText('1.5')).toBeTruthy()
+    expect(screen.getByText('9.5')).toBeTruthy()
+    expect(screen.getByText('1,234')).toBeTruthy()
+    expect(onConnectionStateChange).toHaveBeenCalledWith('connected')
+  })
+
+  it('renders custom groups and trends generically from descriptors', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Sessions')).toBeTruthy()
+    expect(screen.getByText('Activity')).toBeTruthy()
+    expect(screen.getByText('Commands Per Sec')).toBeTruthy()
+    expect(screen.getByText('sessions')).toBeTruthy()
+    // The custom series charts under Trends; the standard series does not.
+    expect(screen.getByText('Trends')).toBeTruthy()
+    expect(screen.getByText('Sessions Active')).toBeTruthy()
+  })
+
+  it('shows only the standard block when a service has no custom metrics', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/timeseries/')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ ...timeseriesResponse, series: [timeseriesResponse.series[0]] })),
+        })
+      }
+      if (url.endsWith('/service/golf_hub')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ ...scalarResponse, custom: [] })),
+        })
+      }
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Serving')).toBeTruthy()
+    expect(screen.queryByText('Sessions')).toBeNull()
+    expect(screen.queryByText('Trends')).toBeNull()
+  })
+
+  it('reports failure and keeps the page shape when the API is down', async () => {
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, text: () => Promise.resolve('') }))
+    const onConnectionStateChange = vi.fn()
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={onConnectionStateChange} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(onConnectionStateChange).toHaveBeenCalledWith('failed')
+    expect(screen.getByText('Serving')).toBeTruthy()
+    expect(screen.getAllByText('No data available').length).toBeGreaterThan(0)
+  })
+})

--- a/src/apps/metrics-systems/pages/MetricsPage.tsx
+++ b/src/apps/metrics-systems/pages/MetricsPage.tsx
@@ -4,6 +4,9 @@ import Navigation from '@/shared/components/Navigation'
 import ConnectionStatus, { ConnectionState } from '@/shared/components/nav/ConnectionStatus'
 import RotatingText from '@/shared/components/nav/RotatingText'
 import MetricsDashboard from '../components/MetricsDashboard'
+import ServiceDashboard from '../components/ServiceDashboard'
+import styles from '../components/MetricsDashboard.module.css'
+import { METRICS_API_URL, fetchJson, serviceDisplayName, type ServiceCatalog } from '../api'
 
 const metricsFacts = [
   "Metrics reveal system health patterns.",
@@ -14,39 +17,72 @@ const metricsFacts = [
   "Metrics are the heartbeat of software."
 ]
 
-const VALID_TABS = ['system', 'containers', 'portrait', 'microgpt'] as const
-type Tab = typeof VALID_TABS[number]
+// Pre-overhaul deep links keep working.
+const LEGACY_TABS: Record<string, string> = {
+  system: 'host',
+  containers: 'host',
+  microgpt: 'microgpt-serve',
+}
 
 const MetricsPage = () => {
   const { tab } = useParams<{ tab: string }>()
   const navigate = useNavigate()
   const [connectionStatus, setConnectionStatus] = useState<ConnectionState>('disconnected')
-
-  const activeTab: Tab = (VALID_TABS as readonly string[]).includes(tab ?? '')
-    ? tab as Tab
-    : 'system'
+  const [catalog, setCatalog] = useState<ServiceCatalog | null>(null)
 
   useEffect(() => {
-    if (!(VALID_TABS as readonly string[]).includes(tab ?? '')) {
-      navigate('/metrics/system', { replace: true })
+    let cancelled = false
+    fetchJson<ServiceCatalog>(`${METRICS_API_URL}/services`).then((result) => {
+      if (!cancelled && result) setCatalog(result)
+    })
+    return () => {
+      cancelled = true
     }
-  }, [tab, navigate])
+  }, [])
+
+  const activeTab = LEGACY_TABS[tab ?? ''] ?? tab ?? 'host'
+
+  useEffect(() => {
+    if (LEGACY_TABS[tab ?? ''] || !tab) {
+      navigate(`/metrics/${LEGACY_TABS[tab ?? ''] ?? 'host'}`, { replace: true })
+      return
+    }
+    // Only bounce unknown names once the catalog can actually judge them.
+    if (catalog && tab !== 'host' && !catalog.services.some((s) => s.name === tab)) {
+      navigate('/metrics/host', { replace: true })
+    }
+  }, [tab, catalog, navigate])
 
   const handleConnectionStateChange = useCallback((status: ConnectionState) => {
     setConnectionStatus(status)
   }, [])
 
-  const handleTabChange = useCallback((newTab: Tab) => {
-    navigate(`/metrics/${newTab}`)
-  }, [navigate])
+  const tabs = [
+    { id: 'host', label: 'Host' },
+    ...(catalog?.services ?? []).map((service) => ({
+      id: service.name,
+      label: serviceDisplayName(service.name),
+    })),
+  ]
 
   return (
-    <div>
-      <MetricsDashboard
-        onConnectionStateChange={handleConnectionStateChange}
-        activeTab={activeTab}
-        onTabChange={handleTabChange}
-      />
+    <div className={styles.dashboard}>
+      <div className={styles.tabNavigation}>
+        {tabs.map((entry) => (
+          <button
+            key={entry.id}
+            className={`${styles.tab} ${activeTab === entry.id ? styles.activeTab : ''}`}
+            onClick={() => navigate(`/metrics/${entry.id}`)}
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === 'host' ? (
+        <MetricsDashboard onConnectionStateChange={handleConnectionStateChange} />
+      ) : (
+        <ServiceDashboard service={activeTab} onConnectionStateChange={handleConnectionStateChange} />
+      )}
       <Navigation
         appName="Metrics"
         context={

--- a/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
+++ b/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import MetricsPage from '../MetricsPage'
+
+vi.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => <div data-testid="line" />,
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div data-testid="bar" />,
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => <div data-testid="cell" />
+}))
+
+const catalogResponse = {
+  services: [
+    { name: 'golf_hub', has_custom: true },
+    { name: 'microgpt-serve', has_custom: true },
+    { name: 'portrait', has_custom: true },
+  ],
+}
+
+const LocationSpy = () => {
+  const location = useLocation()
+  return <span data-testid="location">{location.pathname}</span>
+}
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/metrics/:tab" element={<><MetricsPage /><LocationSpy /></>} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('MetricsPage', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/services')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(catalogResponse)) })
+      }
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    }) as unknown as typeof fetch
+  })
+
+  it('builds tabs from the catalog with Host first', async () => {
+    renderAt('/metrics/host')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const tabs = screen.getAllByRole('button').map((button) => button.textContent)
+    expect(tabs.slice(0, 4)).toEqual(['Host', 'Golf Hub', 'MicroGPT', 'Portrait'])
+    expect(screen.getByText('Host Metrics')).toBeTruthy()
+  })
+
+  it('redirects legacy tabs to their new homes', async () => {
+    renderAt('/metrics/system')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/metrics/host')
+  })
+
+  it('maps the legacy microgpt tab to the catalog name', async () => {
+    renderAt('/metrics/microgpt')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/metrics/microgpt-serve')
+  })
+
+  it('bounces unknown services to host once the catalog loads', async () => {
+    renderAt('/metrics/nonesuch')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/metrics/host')
+  })
+
+  it('renders a service dashboard for a catalog service', async () => {
+    renderAt('/metrics/golf_hub')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Golf Hub' })).toBeTruthy()
+    expect(screen.getByTestId('location').textContent).toBe('/metrics/golf_hub')
+  })
+})


### PR DESCRIPTION
Closes #235, on the deployed MoonBase#1199 API (net −191 lines despite three new files).

**Host page** (`/metrics/host`): `MetricsDashboard` becomes the host view — the existing system and container sections render together, fed by the merged `/host` endpoint; the merged timeseries splits on the `container_` prefix (stripped for the container charts, so all the existing chart code works unchanged). The portrait/microgpt sections, their fetches, and their helpers delete.

**Service pages** (`/metrics/:service`): one generic `ServiceDashboard` — standard serving block above the fold (req/s, error %, avg + p95 ms, active, total; four standard trend charts), custom scalar groups rendered from the API's `{title, metrics: [{label, value, unit}]}` descriptors, and every non-standard series charted generically under Trends. Zero per-service code: golf_hub (which never had a tab), microgpt, portrait, and any future registry entry all render through it.

**Navigation**: tabs come from `/metrics/v1/services` (Host first), so `VALID_TABS` and the hardcoded tab strip delete. Legacy deep links redirect (`system`/`containers` → `host`, `microgpt` → `microgpt-serve`); unknown names bounce to host only after the catalog can actually judge them. `/metrics` now redirects to `/metrics/host`.

Shared `api.ts` carries the wire types and a null-on-failure fetch helper; a tab switch drops the previous service's data during render so a slow fetch can't flash stale numbers under the new title.

**Tests**: 12 across three suites — host view (scalars + container table render, only the merged endpoints are fetched, API-down keeps the page up), service view (standard tiles with unit conversions, descriptor-driven groups/trends, no-custom services show only the standard block, failure reporting), and page (catalog-driven tab order, both legacy redirects, unknown-service bounce, service-dashboard routing). 267 total passing, typecheck + lint clean.

The old prom_proxy per-service routes have no consumers once this deploys — MoonBase#1199's cleanup step can delete them.