### PR TITLE
Metrics: panel fixes — cancel stale fetches, share chart internals

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchJson, serviceDisplayName, splitHostTimeseries, type TimeSeriesResponse } from '../api'
+
+describe('fetchJson', () => {
+  it('parses a successful response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{"a":1}') }) as unknown as typeof fetch
+    expect(await fetchJson<{ a: number }>('/x')).toEqual({ a: 1 })
+  })
+
+  it('returns null on non-ok responses', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve('') }) as unknown as typeof fetch
+    expect(await fetchJson('/x')).toBeNull()
+  })
+
+  it('returns null on empty or whitespace bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('  \n') }) as unknown as typeof fetch
+    expect(await fetchJson('/x')).toBeNull()
+  })
+
+  it('returns null on invalid JSON and thrown fetches', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('nope{') }) as unknown as typeof fetch
+    expect(await fetchJson('/x')).toBeNull()
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch
+    expect(await fetchJson('/x')).toBeNull()
+  })
+})
+
+describe('serviceDisplayName', () => {
+  it('uses the override table for known services', () => {
+    expect(serviceDisplayName('golf_hub')).toBe('Golf Hub')
+    expect(serviceDisplayName('microgpt-serve')).toBe('MicroGPT')
+    expect(serviceDisplayName('portrait')).toBe('Portrait')
+  })
+
+  it('titleizes unknown names on both delimiters', () => {
+    expect(serviceDisplayName('some_new-svc')).toBe('Some New Svc')
+  })
+})
+
+describe('splitHostTimeseries', () => {
+  const merged = {
+    time_range: '1d',
+    start_time: '',
+    end_time: '',
+    step: '30s',
+    series: [
+      { metric_name: 'cpu_utilization', values: [] },
+      { metric_name: 'container_cpu_usage', labels: { name: 'caddy' }, values: [] },
+      { metric_name: 'container_memory_usage_percent', labels: { name: 'caddy' }, values: [] },
+    ],
+  } as TimeSeriesResponse
+
+  it('routes by namespace and strips the container_ prefix', () => {
+    const { system, container } = splitHostTimeseries(merged)
+    expect(system.map((s) => s.metric_name)).toEqual(['cpu_utilization'])
+    expect(container.map((s) => s.metric_name)).toEqual(['cpu_usage', 'memory_usage_percent'])
+    // Labels survive the rename — the container charts key on them.
+    expect(container[0].labels).toEqual({ name: 'caddy' })
+  })
+
+  it('handles an absent series list', () => {
+    const { system, container } = splitHostTimeseries({ ...merged, series: undefined as unknown as TimeSeriesResponse['series'] })
+    expect(system).toEqual([])
+    expect(container).toEqual([])
+  })
+})

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -88,3 +88,23 @@ export function serviceDisplayName(name: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 }
+
+// The host timeseries payload merges host and container series, the
+// latter namespaced with a container_ prefix (see prom_proxy's
+// GetHostMetricsTimeSeries). Split and strip here so chart code keys on
+// the bare cadvisor names.
+export function splitHostTimeseries(merged: TimeSeriesResponse): {
+  system: TimeSeries[]
+  container: TimeSeries[]
+} {
+  const system: TimeSeries[] = []
+  const container: TimeSeries[] = []
+  for (const series of merged.series ?? []) {
+    if (series.metric_name.startsWith('container_')) {
+      container.push({ ...series, metric_name: series.metric_name.slice('container_'.length) })
+    } else {
+      system.push(series)
+    }
+  }
+  return { system, container }
+}

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
+import { METRICS_API_URL, fetchJson, splitHostTimeseries, type TimeSeriesResponse } from '../api'
 
 interface SystemMetrics {
   timestamp: string
@@ -29,23 +30,6 @@ interface SystemMetrics {
     tx_rate_bytes_per_sec: number
     errors_per_sec: number
   }>
-}
-
-interface TimeSeries {
-  metric_name: string
-  labels?: Record<string, string>
-  values: Array<{
-    timestamp: string
-    value: number
-  }>
-}
-
-interface TimeSeriesResponse {
-  time_range: string
-  start_time: string
-  end_time: string
-  step: string
-  series: TimeSeries[]
 }
 
 interface ContainerStats {
@@ -143,65 +127,45 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
 
-  const fetchMetrics = useCallback(async () => {
-    try {
-      // Use setTimeout to avoid synchronous state update in useEffect
-      setTimeout(() => onConnectionStateChange('connecting'), 0)
+  useEffect(() => {
+    // The flag discards resolutions that land after a range change (or
+    // unmount), so a slow fetch can't write back stale data.
+    let active = true
+    const fetchMetrics = async () => {
+      onConnectionStateChange('connecting')
 
-      // Use environment variable for API URL, defaulting to production URL
-      const apiUrl = import.meta.env.VITE_METRICS_API_URL || 'https://api.muchq.com/metrics/v1'
+      const [hostData, merged] = await Promise.all([
+        fetchJson<HostMetricsResponse>(`${METRICS_API_URL}/host`),
+        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/host/timeseries/${timeRange}`),
+      ])
+      if (!active) return
 
-      // The merged host endpoint (#1199): system + per-container scalars in
-      // one payload, container series namespaced container_* in the other.
-      try {
-        const hostResponse = await fetch(`${apiUrl}/host`)
-        if (hostResponse.ok) {
-          const text = await hostResponse.text()
-          if (text.trim()) {
-            const hostData: HostMetricsResponse = JSON.parse(text)
-            if (hostData.system) setSystemMetrics(hostData.system)
-            setContainerMetrics({ timestamp: hostData.timestamp, containers: hostData.containers || [] })
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
+      if (hostData) {
+        if (hostData.system) setSystemMetrics(hostData.system)
+        setContainerMetrics({ timestamp: hostData.timestamp, containers: hostData.containers || [] })
+      }
+      if (merged) {
+        const { system, container } = splitHostTimeseries(merged)
+        setSystemTimeseries({ ...merged, series: system })
+        setContainerTimeseries({ ...merged, series: container })
       }
 
-      try {
-        const hostTimeseriesResponse = await fetch(`${apiUrl}/host/timeseries/${timeRange}`)
-        if (hostTimeseriesResponse.ok) {
-          const text = await hostTimeseriesResponse.text()
-          if (text.trim()) {
-            const merged: TimeSeriesResponse = JSON.parse(text)
-            const hostSeries: TimeSeries[] = []
-            const containerSeries: TimeSeries[] = []
-            for (const series of merged.series || []) {
-              if (series.metric_name.startsWith('container_')) {
-                containerSeries.push({ ...series, metric_name: series.metric_name.slice('container_'.length) })
-              } else {
-                hostSeries.push(series)
-              }
-            }
-            setSystemTimeseries({ ...merged, series: hostSeries })
-            setContainerTimeseries({ ...merged, series: containerSeries })
-          }
-        }
-      } catch {
-        // Silently handle error - UI will show "no data" state
+      if (hostData || merged) {
+        setLastUpdate(new Date())
+        onConnectionStateChange('connected')
+      } else {
+        onConnectionStateChange('failed')
       }
+    }
 
-      setLastUpdate(new Date())
-      onConnectionStateChange('connected')
-    } catch {
-      onConnectionStateChange('failed')
+    const start = setTimeout(fetchMetrics, 0)
+    const interval = setInterval(fetchMetrics, 30000) // Update every 30 seconds
+    return () => {
+      active = false
+      clearTimeout(start)
+      clearInterval(interval)
     }
   }, [timeRange, onConnectionStateChange])
-
-  useEffect(() => {
-    setTimeout(fetchMetrics, 0)
-    const interval = setInterval(fetchMetrics, 30000) // Update every 30 seconds
-    return () => clearInterval(interval)
-  }, [fetchMetrics])
 
   const formatTimestamp = (timestamp: string) => {
     return new Date(timestamp).toLocaleTimeString()
@@ -411,8 +375,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
 
       {/* Tab Content */}
       <div className={styles.metricsGrid}>
-        {(
-          <>
+        <>
             {/* System Overview Cards */}
             {systemMetrics && (
               <div className={styles.overviewCards}>
@@ -634,11 +597,9 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
             </div>
           </div>
         </div>
-          </>
-        )}
+        </>
 
-        {(
-          <>
+        <>
             {/* Container Overview Cards */}
             {containerMetrics && containerMetrics.containers.length > 0 && (
               <div className={styles.overviewCards}>
@@ -948,8 +909,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                 </div>
               </div>
             </div>
-          </>
-        )}
+        </>
       </div>
     </div>
   )

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
@@ -18,6 +18,9 @@ interface ServiceDashboardProps {
 
 // The five series every service page charts; anything else in the
 // timeseries payload is a custom series and renders generically below.
+// Must match the keys of standardTimeseriesQueries in prom_proxy's
+// registry.go — and custom series names must not collide with these, or
+// they classify as standard and never chart.
 const STANDARD_SERIES = new Set([
   'request_rate',
   'error_rate_percent',
@@ -57,40 +60,42 @@ const SeriesChart = ({
   const formatTimestamp = (timestamp: string) =>
     new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
+  if (!series?.values?.length) {
+    return (
+      <div className={styles.compactChart}>
+        <h4>{title}</h4>
+        <NoDataMessage />
+      </div>
+    )
+  }
+
+  const data = series.values.map((v) => ({
+    time: formatTimestamp(v.timestamp),
+    value: scale(Math.max(0, v.value || 0)),
+  }))
+  const ChartComponent = area ? AreaChart : LineChart
+
   return (
     <div className={styles.compactChart}>
       <h4>{title}</h4>
-      {series?.values?.length ? (
-        <ChartErrorBoundary>
-          <ResponsiveContainer width="100%" height={180}>
+      <ChartErrorBoundary>
+        <ResponsiveContainer width="100%" height={180}>
+          <ChartComponent data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+            <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
+            <YAxis stroke="#888" fontSize={10} />
+            <Tooltip
+              contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+              formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
+            />
             {area ? (
-              <AreaChart data={series.values.map((v) => ({ time: formatTimestamp(v.timestamp), value: scale(Math.max(0, v.value || 0)) }))}>
-                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                <YAxis stroke="#888" fontSize={10} />
-                <Tooltip
-                  contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                  formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
-                />
-                <Area type="monotone" dataKey="value" stroke={color} fill={`${color}44`} strokeWidth={2} />
-              </AreaChart>
+              <Area type="monotone" dataKey="value" stroke={color} fill={`${color}44`} strokeWidth={2} />
             ) : (
-              <LineChart data={series.values.map((v) => ({ time: formatTimestamp(v.timestamp), value: scale(Math.max(0, v.value || 0)) }))}>
-                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                <XAxis dataKey="time" stroke="#888" fontSize={10} interval="preserveStartEnd" />
-                <YAxis stroke="#888" fontSize={10} />
-                <Tooltip
-                  contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                  formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
-                />
-                <Line type="monotone" dataKey="value" stroke={color} strokeWidth={2} dot={false} />
-              </LineChart>
+              <Line type="monotone" dataKey="value" stroke={color} strokeWidth={2} dot={false} />
             )}
-          </ResponsiveContainer>
-        </ChartErrorBoundary>
-      ) : (
-        <NoDataMessage />
-      )}
+          </ChartComponent>
+        </ResponsiveContainer>
+      </ChartErrorBoundary>
     </div>
   )
 }
@@ -110,29 +115,39 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
     setTimeseries(null)
   }
 
-  const fetchMetrics = useCallback(async () => {
-    setTimeout(() => onConnectionStateChange('connecting'), 0)
+  useEffect(() => {
+    // The flag discards resolutions that land after a service or range
+    // switch — without it, a slow fetch for the previous service would
+    // write its data back under the new title.
+    let active = true
+    const fetchMetrics = async () => {
+      onConnectionStateChange('connecting')
 
-    const [scalarData, seriesData] = await Promise.all([
-      fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}`),
-      fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
-    ])
-    if (scalarData) setScalar(scalarData)
-    if (seriesData) setTimeseries(seriesData)
+      const [scalarData, seriesData] = await Promise.all([
+        fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}`),
+        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
+      ])
+      if (!active) return
 
-    if (scalarData || seriesData) {
-      setLastUpdate(new Date())
-      onConnectionStateChange('connected')
-    } else {
-      onConnectionStateChange('failed')
+      if (scalarData) setScalar(scalarData)
+      if (seriesData) setTimeseries(seriesData)
+
+      if (scalarData || seriesData) {
+        setLastUpdate(new Date())
+        onConnectionStateChange('connected')
+      } else {
+        onConnectionStateChange('failed')
+      }
+    }
+
+    const start = setTimeout(fetchMetrics, 0)
+    const interval = setInterval(fetchMetrics, 30000)
+    return () => {
+      active = false
+      clearTimeout(start)
+      clearInterval(interval)
     }
   }, [service, timeRange, onConnectionStateChange])
-
-  useEffect(() => {
-    setTimeout(fetchMetrics, 0)
-    const interval = setInterval(fetchMetrics, 30000)
-    return () => clearInterval(interval)
-  }, [fetchMetrics])
 
   const findSeries = (name: string) => timeseries?.series?.find((s) => s.metric_name === name)
   const customSeries = (timeseries?.series ?? []).filter((s) => !STANDARD_SERIES.has(s.metric_name))

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act, screen } from '@testing-library/react'
+import { render, act, screen, fireEvent } from '@testing-library/react'
 import MetricsDashboard from '../MetricsDashboard'
 
 // Mock the recharts library to avoid canvas issues in tests
@@ -109,6 +109,23 @@ describe('MetricsDashboard (host view)', () => {
     expect(urls.some((url) => url.includes('/host/timeseries/'))).toBe(true)
     expect(urls.some((url) => url.includes('/scalar/'))).toBe(false)
     expect(urls.some((url) => url.includes('/timeseries/system'))).toBe(false)
+  })
+
+  it('refetches with the selected range', async () => {
+    const { container } = render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const select = container.querySelector('select')!
+    fireEvent.change(select, { target: { value: '7d' } })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((url) => url.endsWith('/host/timeseries/7d'))).toBe(true)
   })
 
   it('stays up with empty sections when the API is down', async () => {

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act, screen } from '@testing-library/react'
+import { render, act, screen, fireEvent } from '@testing-library/react'
 import ServiceDashboard from '../ServiceDashboard'
 
 vi.mock('recharts', () => ({
@@ -120,6 +120,43 @@ describe('ServiceDashboard', () => {
     expect(screen.getByText('Serving')).toBeTruthy()
     expect(screen.queryByText('Sessions')).toBeNull()
     expect(screen.queryByText('Trends')).toBeNull()
+  })
+
+  it('drops stale data and refetches when the service changes', async () => {
+    const { rerender } = render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+    expect(screen.getByText('Sessions')).toBeTruthy()
+
+    // Portrait's endpoints resolve to nothing, so anything still on
+    // screen after the switch would be golf_hub's stale data.
+    rerender(<ServiceDashboard service="portrait" onConnectionStateChange={vi.fn()} />)
+    expect(screen.queryByText('Sessions')).toBeNull()
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+    expect(screen.queryByText('Sessions')).toBeNull()
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((url) => url.endsWith('/service/portrait'))).toBe(true)
+  })
+
+  it('refetches with the selected range', async () => {
+    const { container } = render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    fireEvent.change(container.querySelector('select')!, { target: { value: '30m' } })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((url) => url.endsWith('/service/golf_hub/timeseries/30m'))).toBe(true)
   })
 
   it('reports failure and keeps the page shape when the API is down', async () => {

--- a/src/apps/metrics-systems/pages/MetricsPage.tsx
+++ b/src/apps/metrics-systems/pages/MetricsPage.tsx
@@ -47,7 +47,9 @@ const MetricsPage = () => {
       navigate(`/metrics/${LEGACY_TABS[tab ?? ''] ?? 'host'}`, { replace: true })
       return
     }
-    // Only bounce unknown names once the catalog can actually judge them.
+    // Only bounce unknown names once the catalog can actually judge them;
+    // if the catalog never loads, unknown names stay in place (an empty
+    // service page) rather than guessing at a redirect.
     if (catalog && tab !== 'host' && !catalog.services.some((s) => s.name === tab)) {
       navigate('/metrics/host', { replace: true })
     }

--- a/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
+++ b/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
@@ -94,6 +94,21 @@ describe('MetricsPage', () => {
     expect(screen.getByTestId('location').textContent).toBe('/metrics/host')
   })
 
+  it('keeps the Host page alive when the catalog never loads', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    ) as unknown as typeof fetch
+
+    renderAt('/metrics/host')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Host Metrics')).toBeTruthy()
+    expect(screen.getAllByRole('button').map((b) => b.textContent)).toContain('Host')
+  })
+
   it('renders a service dashboard for a catalog service', async () => {
     renderAt('/metrics/golf_hub')
 


### PR DESCRIPTION
Review-panel follow-on to #237 (companion to MoonBase#1201, which carries the Caddy routing fix that actually unblocks the deployed page).

**Correctness (the panel's real find):** a slow fetch for the previous service could resolve after a tab switch and write its data back under the new title — and if the new service's endpoint was down, the stale data stuck permanently since null responses never overwrite. Both dashboards now fold fetching into the effect with a cancellation flag scoped to service/range; the reset-during-render stays for the instant clear. The host view also stops claiming "Live Data" unconditionally — it reports failure when both endpoints yield nothing (exactly the misleading badge in your outage screenshot).

**Simplification:** the `container_` split moves to `api.ts` as a pure, tested `splitHostTimeseries`; `SeriesChart` branches only on the wrapper + mark instead of duplicating grid/axes/tooltip across the area/line arms; `MetricsDashboard` adopts `fetchJson` and the shared wire types instead of hand-rolling both; the vestigial always-true `{(…)}` wrappers from the tab surgery unwrap. Weighed and left per repo convention: the triplicated recharts test mock (the repo consistently inlines test mocks), the near-duplicate title-casers (different domains, not lockstep).

**Coverage (12 new tests, 279 total):** `api.test.ts` for `fetchJson`'s four exits, `serviceDisplayName`'s override + titleize paths, and the split's routing/strip/label-preservation (an inverted prefix check now fails two assertions instead of zero); service-switch staleness (rerender to a dead service, assert the old data never reappears); range refetch for both dashboards; catalog-outage survival of the Host page, with the never-loads behavior now stated at the bounce guard. `STANDARD_SERIES` carries the cross-reference to the Go registry (Go side in MoonBase#1201).

Left unmerged for your review.