### PR TITLE
posterize: handle multiple image formats end to end

### DIFF
--- a/src/apps/posterize/__tests__/imageFormat.test.ts
+++ b/src/apps/posterize/__tests__/imageFormat.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatToMime,
+  formatToExtension,
+  imageFormatInfo,
+} from '../imageFormat'
+
+describe('imageFormat', () => {
+  it('maps known formats to their MIME type', () => {
+    expect(formatToMime('PNG')).toBe('image/png')
+    expect(formatToMime('JPEG')).toBe('image/jpeg')
+    expect(formatToMime('GIF')).toBe('image/gif')
+    expect(formatToMime('BMP')).toBe('image/bmp')
+    expect(formatToMime('TIFF')).toBe('image/tiff')
+    expect(formatToMime('WEBP')).toBe('image/webp')
+    expect(formatToMime('ICO')).toBe('image/x-icon')
+  })
+
+  it('maps known formats to their file extension', () => {
+    expect(formatToExtension('PNG')).toBe('png')
+    expect(formatToExtension('JPEG')).toBe('jpg')
+    expect(formatToExtension('TIFF')).toBe('tiff')
+  })
+
+  it('is case-insensitive on the format label', () => {
+    expect(formatToMime('jpeg')).toBe('image/jpeg')
+    expect(formatToExtension('Gif')).toBe('gif')
+  })
+
+  it('falls back to PNG for unknown, empty, or missing formats', () => {
+    expect(imageFormatInfo('SVG')).toEqual({ mime: 'image/png', extension: 'png' })
+    expect(formatToMime('')).toBe('image/png')
+    expect(formatToMime(null)).toBe('image/png')
+    expect(formatToMime(undefined)).toBe('image/png')
+  })
+})

--- a/src/apps/posterize/components/ImageUploader.tsx
+++ b/src/apps/posterize/components/ImageUploader.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react'
 import styles from './ImageUploader.module.css'
+import { ACCEPTED_UPLOAD_MIME_TYPES } from '../imageFormat'
 
 interface ImageUploaderProps {
   onImageSelect: (base64: string) => void
@@ -12,8 +13,8 @@ const ImageUploader = ({ onImageSelect, isLoading }: ImageUploaderProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const processFile = useCallback((file: File) => {
-    if (!file.type.startsWith('image/png')) {
-      alert('Please select a PNG image file')
+    if (!file.type.startsWith('image/')) {
+      alert('Please select an image file (PNG, JPEG, GIF, BMP, TIFF, or WebP)')
       return
     }
 
@@ -21,7 +22,7 @@ const ImageUploader = ({ onImageSelect, isLoading }: ImageUploaderProps) => {
     reader.onload = (e) => {
       const result = e.target?.result as string
       if (result) {
-        // Extract base64 data (remove data:image/png;base64, prefix)
+        // Extract base64 data (strip the leading data:<mime>;base64, prefix)
         const base64Data = result.split(',')[1]
         setPreviewUrl(result)
         onImageSelect(base64Data)
@@ -65,7 +66,7 @@ const ImageUploader = ({ onImageSelect, isLoading }: ImageUploaderProps) => {
         for (const type of clipboardItem.types) {
           if (type.startsWith('image/')) {
             const blob = await clipboardItem.getType(type)
-            const file = new File([blob], 'pasted-image.png', { type: 'image/png' })
+            const file = new File([blob], 'pasted-image', { type })
             processFile(file)
             return
           }
@@ -96,7 +97,7 @@ const ImageUploader = ({ onImageSelect, isLoading }: ImageUploaderProps) => {
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/png"
+          accept={ACCEPTED_UPLOAD_MIME_TYPES.join(',')}
           onChange={handleFileInput}
           className={styles.hiddenInput}
         />
@@ -111,8 +112,8 @@ const ImageUploader = ({ onImageSelect, isLoading }: ImageUploaderProps) => {
         ) : (
           <div className={styles.uploadPrompt}>
             <div className={styles.uploadIcon}>📁</div>
-            <h3>Drop your PNG here</h3>
-            <p>or click to browse files</p>
+            <h3>Drop your image here</h3>
+            <p>PNG, JPEG, GIF, BMP, TIFF, or WebP — or click to browse files</p>
           </div>
         )}
       </div>

--- a/src/apps/posterize/imageFormat.ts
+++ b/src/apps/posterize/imageFormat.ts
@@ -1,0 +1,44 @@
+/**
+ * Maps the posterize API's `format` field (e.g. "PNG", "JPEG") to the MIME type
+ * and file extension the browser needs for rendering, downloading, and copying.
+ * The API returns the image in the same format it received where an encoder is
+ * available; WebP/ICO inputs come back as PNG.
+ */
+export interface ImageFormatInfo {
+  mime: string
+  extension: string
+}
+
+const FORMAT_INFO: Record<string, ImageFormatInfo> = {
+  PNG: { mime: 'image/png', extension: 'png' },
+  JPEG: { mime: 'image/jpeg', extension: 'jpg' },
+  GIF: { mime: 'image/gif', extension: 'gif' },
+  BMP: { mime: 'image/bmp', extension: 'bmp' },
+  TIFF: { mime: 'image/tiff', extension: 'tiff' },
+  WEBP: { mime: 'image/webp', extension: 'webp' },
+  ICO: { mime: 'image/x-icon', extension: 'ico' },
+}
+
+const DEFAULT_INFO: ImageFormatInfo = FORMAT_INFO.PNG
+
+/** Look up MIME + extension for an API format label, defaulting to PNG. */
+export const imageFormatInfo = (format: string | null | undefined): ImageFormatInfo => {
+  if (!format) return DEFAULT_INFO
+  return FORMAT_INFO[format.toUpperCase()] ?? DEFAULT_INFO
+}
+
+export const formatToMime = (format: string | null | undefined): string =>
+  imageFormatInfo(format).mime
+
+export const formatToExtension = (format: string | null | undefined): string =>
+  imageFormatInfo(format).extension
+
+/** MIME types the posterize backend can decode, used for the upload filter. */
+export const ACCEPTED_UPLOAD_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/bmp',
+  'image/tiff',
+  'image/webp',
+] as const

--- a/src/apps/posterize/pages/PosterizePage.tsx
+++ b/src/apps/posterize/pages/PosterizePage.tsx
@@ -4,6 +4,7 @@ import Navigation from '@/shared/components/Navigation'
 import NavTagline from '@/shared/components/nav/NavTagline'
 import ImageUploader from '../components/ImageUploader'
 import { handleApiResponse } from '@/utils/apiUtils'
+import { formatToMime, formatToExtension } from '../imageFormat'
 
 interface BlurResponse {
   width: number
@@ -129,9 +130,11 @@ const PosterizePage = () => {
   const downloadImage = () => {
     if (!blurredImage) return
 
+    const mime = formatToMime(blurredImage.format)
+    const extension = formatToExtension(blurredImage.format)
     const link = document.createElement('a')
-    link.href = `data:image/png;base64,${blurredImage.image_data}`
-    link.download = 'blurred-image.png'
+    link.href = `data:${mime};base64,${blurredImage.image_data}`
+    link.download = `posterized-image.${extension}`
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
@@ -141,9 +144,24 @@ const PosterizePage = () => {
     if (!blurredImage) return
 
     try {
-      // Convert base64 to blob
-      const response = await fetch(`data:image/png;base64,${blurredImage.image_data}`)
-      const blob = await response.blob()
+      // Browser clipboard image support is effectively PNG-only, so re-encode
+      // whatever format the API returned to PNG via a canvas before copying.
+      const mime = formatToMime(blurredImage.format)
+      const image = new Image()
+      image.src = `data:${mime};base64,${blurredImage.image_data}`
+      await image.decode()
+
+      const canvas = document.createElement('canvas')
+      canvas.width = image.naturalWidth
+      canvas.height = image.naturalHeight
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas is not supported')
+      ctx.drawImage(image, 0, 0)
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, 'image/png')
+      )
+      if (!blob) throw new Error('Failed to encode image')
 
       await navigator.clipboard.write([
         new ClipboardItem({
@@ -267,7 +285,7 @@ const PosterizePage = () => {
               <div className={styles.result}>
                 <img
                   id="result-image"
-                  src={`data:image/png;base64,${blurredImage.image_data}`}
+                  src={`data:${formatToMime(blurredImage.format)};base64,${blurredImage.image_data}`}
                   alt="Processed result"
                   className={styles.resultImage}
                 />


### PR DESCRIPTION
## Summary

Companion to the posterize backend change (muchq/MoonBase#1207), which now accepts common image formats and returns the result in the same format it received, reporting the real type in the response `format` field. The UI previously assumed PNG everywhere; this consumes the returned format.

- **New `imageFormat` helper** maps the API `format` label to a MIME type and file extension (falls back to PNG for unknown/empty).
- **Render / download** derive MIME + extension from the returned format, so a JPEG round-trip downloads as `.jpg` instead of a mislabeled `.png`.
- **Copy-to-clipboard** re-encodes to PNG via a canvas before writing. Browser clipboard image support is effectively PNG-only, so a non-PNG blob otherwise failed the write (a regression once outputs stopped always being PNG).
- **Uploader** accepts PNG, JPEG, GIF, BMP, TIFF, and WebP, and the paste path preserves the pasted image's real MIME type (previously it was forced to `image/png`).

## Testing

- Added `imageFormat.test.ts` (format→MIME/extension mapping, case-insensitivity, fallback).
- `npm run typecheck`, `npm run lint` (zero warnings), `npx vitest run` (**283 tests, all passing**), and `npm run build` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX1aN5cBSm7rqmzLQMAoXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX1aN5cBSm7rqmzLQMAoXL)_