### PR TITLE
metrics: container health on the service and host pages

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi } from 'vitest'
-import { fetchJson, serviceDisplayName, splitHostTimeseries, type TimeSeriesResponse } from '../api'
+import {
+  byHealthThenName,
+  containerDisplayName,
+  containerLabel,
+  fetchJson,
+  formatUptime,
+  serviceDisplayName,
+  splitHostTimeseries,
+  type ContainerStats,
+  type TimeSeriesResponse,
+} from '../api'
 
 describe('fetchJson', () => {
   it('parses a successful response', async () => {
@@ -62,5 +72,85 @@ describe('splitHostTimeseries', () => {
     const { system, container } = splitHostTimeseries({ ...merged, series: undefined as unknown as TimeSeriesResponse['series'] })
     expect(system).toEqual([])
     expect(container).toEqual([])
+  })
+})
+
+const stats = (overrides: Partial<ContainerStats> & { name: string }): ContainerStats => ({
+  cpu_usage_percent: 0,
+  cpu_throttled_seconds: 0,
+  memory_usage_bytes: 0,
+  memory_limit_bytes: 0,
+  memory_usage_percent: 0,
+  network_rx_bytes_per_sec: 0,
+  network_tx_bytes_per_sec: 0,
+  restarts_last_hour: 0,
+  uptime_seconds: 0,
+  crash_looping: false,
+  ...overrides,
+})
+
+describe('containerDisplayName', () => {
+  it('strips the compose project prefix and the replica index', () => {
+    expect(containerDisplayName('ubuntu-golf_hub-1')).toBe('golf_hub')
+  })
+
+  it('only strips a trailing index, so a two-digit replica survives', () => {
+    // An unanchored replace('-1', '') cuts the first literal "-1" anywhere,
+    // which turns caddy-10 into caddy0 and svc-1x into svcx.
+    expect(containerDisplayName('ubuntu-caddy-10')).toBe('caddy')
+    expect(containerDisplayName('ubuntu-svc-1x')).toBe('svc-1x')
+  })
+
+  it('leaves a name with no prefix or index alone', () => {
+    expect(containerDisplayName('caddy')).toBe('caddy')
+  })
+})
+
+describe('containerLabel', () => {
+  it('prefers the compose service label over the container name', () => {
+    // The name parse is a guess about the project prefix, which differs
+    // between the deployed host and local_deploy.sh. The label is a fact.
+    expect(containerLabel(stats({ name: 'moonbase-golf_hub-1', service: 'golf_hub' }))).toBe('golf_hub')
+  })
+
+  it('falls back to the parsed name when the label is missing or empty', () => {
+    expect(containerLabel(stats({ name: 'ubuntu-caddy-1' }))).toBe('caddy')
+    expect(containerLabel(stats({ name: 'ubuntu-caddy-1', service: '' }))).toBe('caddy')
+  })
+})
+
+describe('byHealthThenName', () => {
+  it('puts a crash-looping container first even with fewer restarts', () => {
+    const looping = stats({ name: 'a', service: 'a', crash_looping: true, restarts_last_hour: 3 })
+    const noisy = stats({ name: 'b', service: 'b', restarts_last_hour: 40 })
+    expect([noisy, looping].sort(byHealthThenName).map((c) => c.service)).toEqual(['a', 'b'])
+  })
+
+  it('orders the rest by restart count before falling back to the name', () => {
+    const quiet = stats({ name: 'a', service: 'a' })
+    const restarted = stats({ name: 'z', service: 'z', restarts_last_hour: 2 })
+    expect([quiet, restarted].sort(byHealthThenName).map((c) => c.service)).toEqual(['z', 'a'])
+  })
+
+  it('is a stable alphabetical sort when everything is healthy', () => {
+    const names = ['prometheus', 'caddy', 'golf_hub']
+    const sorted = names.map((n) => stats({ name: n, service: n })).sort(byHealthThenName)
+    expect(sorted.map((c) => c.service)).toEqual(['caddy', 'golf_hub', 'prometheus'])
+  })
+})
+
+describe('formatUptime', () => {
+  it('picks the largest whole unit', () => {
+    expect(formatUptime(8)).toBe('8s')
+    expect(formatUptime(90)).toBe('1m')
+    expect(formatUptime(7200)).toBe('2h')
+    expect(formatUptime(172800)).toBe('2d')
+  })
+
+  it('renders a dash rather than 0s for absent data', () => {
+    // A container Prometheus has never seen arrives as zero, and "0s uptime"
+    // reads like a fact about a running container.
+    expect(formatUptime(0)).toBe('—')
+    expect(formatUptime(NaN)).toBe('—')
   })
 })

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -43,6 +43,73 @@ export interface ServiceMetricsResponse {
   custom: CustomMetricGroup[]
 }
 
+// Per-container stats. A service that dies during startup never serves a
+// request, so its http_server_* series stay flat and read as idle — restarts
+// and uptime are the only thing separating "crash-looping" from "quiet"
+// (MoonBase#1215).
+export interface ContainerStats {
+  name: string
+  // The compose service behind the container, stamped by the daemon. Optional
+  // only because the UI deploys independently of prom_proxy: a Pages build can
+  // land while the host is still running an image from before MoonBase#1218.
+  service?: string
+  cpu_usage_percent: number
+  cpu_throttled_seconds: number
+  memory_usage_bytes: number
+  memory_limit_bytes: number
+  memory_usage_percent: number
+  network_rx_bytes_per_sec: number
+  network_tx_bytes_per_sec: number
+  restarts_last_hour: number
+  uptime_seconds: number
+  crash_looping: boolean
+  // Deploys pin images per commit (MoonBase#1210), so the tag is the revision
+  // actually running — as opposed to whatever the host was told to run.
+  image?: string
+  version?: string
+  // False when cAdvisor returned nothing. Without it a failed query leaves
+  // zeroes, and zero restarts with zero uptime reads as a healthy container.
+  reporting?: boolean
+}
+
+// Single-container response from /metrics/v1/container/{name}.
+export interface ContainerDetail {
+  timestamp: string
+  container: ContainerStats
+}
+
+// Compose names containers `<project>-<service>-<index>`, e.g.
+// `ubuntu-golf_hub-1`. Strip both ends so a container lines up with the service
+// it backs. The index is anchored: a bare `-1` replace also mangles `svc-10`.
+export function containerDisplayName(name: string): string {
+  return name.replace(/^ubuntu-/, '').replace(/-\d+$/, '')
+}
+
+// Prefer the daemon's label over re-deriving it from the container name: the
+// project prefix differs between the deployed host and local_deploy.sh, so
+// parsing is a guess where the label is a fact. Falls back for payloads from a
+// prom_proxy older than MoonBase#1218.
+export function containerLabel(container: ContainerStats): string {
+  return container.service || containerDisplayName(container.name)
+}
+
+// Crash-looping first, then whatever else is restarting, so a failing container
+// can't sit below the fold of a long list.
+export function byHealthThenName(a: ContainerStats, b: ContainerStats): number {
+  if (!!a.crash_looping !== !!b.crash_looping) return a.crash_looping ? -1 : 1
+  const restarts = (b.restarts_last_hour ?? 0) - (a.restarts_last_hour ?? 0)
+  if (restarts !== 0) return restarts
+  return containerLabel(a).localeCompare(containerLabel(b))
+}
+
+export function formatUptime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '—'
+  if (seconds < 60) return `${Math.floor(seconds)}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
+  return `${Math.floor(seconds / 86400)}d`
+}
+
 export interface TimeSeries {
   metric_name: string
   labels?: Record<string, string>

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -1,0 +1,75 @@
+import styles from './MetricsDashboard.module.css'
+import { containerLabel, formatUptime, type ContainerStats } from '../api'
+
+// Three states a service page can't distinguish on its own. Every panel above
+// this strip is built from http_server_* series, and a container that dies
+// before it binds a port emits none of them — which looks exactly like an idle
+// but healthy service: flat lines, no errors, no gap.
+//
+//   null            the endpoint 404'd or the fetch failed — no container
+//   reporting=false cAdvisor knows the container but returned no samples
+//   otherwise       real numbers, so up/restarting/crash-looping is decidable
+//
+// The middle case has to stay distinct from a healthy zero: a failed query
+// leaves 0 restarts and 0 uptime, which would otherwise render as "up".
+export function ContainerHealthStrip({ container }: { container: ContainerStats | null }) {
+  if (!container) {
+    return (
+      <div className={styles.overviewCards} data-testid="container-health">
+        <div className={styles.miniCard}>
+          <div className={styles.miniLabel}>Container</div>
+          <div className={styles.miniValue} data-testid="container-state">
+            unknown
+          </div>
+          <div className={styles.miniUnit}>no container found</div>
+        </div>
+      </div>
+    )
+  }
+
+  // Optional so a payload from a prom_proxy older than MoonBase#1218 (which has
+  // no `reporting` field) reads as reporting rather than silently degraded.
+  const reporting = container.reporting !== false
+  const restarts = container.restarts_last_hour ?? 0
+  const state = !reporting
+    ? 'not reporting'
+    : container.crash_looping
+      ? 'crash looping'
+      : restarts > 0
+        ? 'restarting'
+        : 'up'
+
+  return (
+    <div className={styles.overviewCards} data-testid="container-health">
+      <div className={styles.miniCard}>
+        <div className={styles.miniLabel}>Container</div>
+        <div className={styles.miniValue} data-testid="container-state">
+          {state}
+        </div>
+        <div className={styles.miniUnit}>{containerLabel(container)}</div>
+      </div>
+      <div className={styles.miniCard}>
+        <div className={styles.miniLabel}>Uptime</div>
+        <div className={styles.miniValue} data-testid="container-uptime">
+          {reporting ? formatUptime(container.uptime_seconds) : '—'}
+        </div>
+      </div>
+      <div className={styles.miniCard}>
+        <div className={styles.miniLabel}>Restarts</div>
+        <div className={styles.miniValue} data-testid="container-restarts">
+          {reporting ? restarts : '—'}
+        </div>
+        <div className={styles.miniUnit}>last hour</div>
+      </div>
+      <div className={styles.miniCard}>
+        <div className={styles.miniLabel}>Version</div>
+        <div className={styles.miniValue} data-testid="container-version">
+          {container.version || '—'}
+        </div>
+        <div className={styles.miniUnit}>running</div>
+      </div>
+    </div>
+  )
+}
+
+export default ContainerHealthStrip

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -6,7 +6,9 @@ import { containerLabel, formatUptime, type ContainerStats } from '../api'
 // before it binds a port emits none of them — which looks exactly like an idle
 // but healthy service: flat lines, no errors, no gap.
 //
-//   null            the endpoint 404'd or the fetch failed — no container
+//   null            the endpoint 404'd or the fetch failed. These are not the
+//                   same thing, and fetchJson can't tell them apart, so this
+//                   renders "unknown" rather than claiming the container is gone
 //   reporting=false cAdvisor knows the container but returned no samples
 //   otherwise       real numbers, so up/restarting/crash-looping is decidable
 //
@@ -21,7 +23,7 @@ export function ContainerHealthStrip({ container }: { container: ContainerStats 
           <div className={styles.miniValue} data-testid="container-state">
             unknown
           </div>
-          <div className={styles.miniUnit}>no container found</div>
+          <div className={styles.miniUnit}>no data</div>
         </div>
       </div>
     )

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -2,7 +2,17 @@ import { useState, useEffect } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
-import { METRICS_API_URL, fetchJson, splitHostTimeseries, type TimeSeriesResponse } from '../api'
+import {
+  METRICS_API_URL,
+  byHealthThenName,
+  containerDisplayName,
+  containerLabel,
+  fetchJson,
+  formatUptime,
+  splitHostTimeseries,
+  type ContainerStats,
+  type TimeSeriesResponse,
+} from '../api'
 
 interface SystemMetrics {
   timestamp: string
@@ -30,17 +40,6 @@ interface SystemMetrics {
     tx_rate_bytes_per_sec: number
     errors_per_sec: number
   }>
-}
-
-interface ContainerStats {
-  name: string
-  cpu_usage_percent: number
-  cpu_throttled_seconds: number
-  memory_usage_bytes: number
-  memory_limit_bytes: number
-  memory_usage_percent: number
-  network_rx_bytes_per_sec: number
-  network_tx_bytes_per_sec: number
 }
 
 interface ContainerMetrics {
@@ -600,13 +599,26 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
         </>
 
         <>
-            {/* Container Overview Cards */}
+            {/* Container Overview Cards — every container, not the first four.
+                The host runs more than four, and the truncated list was in
+                arbitrary Prometheus order, so the one container worth looking
+                at was the one most likely to be cut. Sorted so anything
+                crash-looping or restarting sorts to the front. */}
             {containerMetrics && containerMetrics.containers.length > 0 && (
-              <div className={styles.overviewCards}>
-                {containerMetrics.containers.slice(0, 4).map(container => (
+              <div className={styles.overviewCards} data-testid="container-cards">
+                {[...containerMetrics.containers].sort(byHealthThenName).map(container => (
                   <div key={container.name} className={styles.miniCard}>
-                    <div className={styles.miniLabel}>{container.name.replace('ubuntu-', '').replace('-1', '')}</div>
+                    <div className={styles.miniLabel}>{containerLabel(container)}</div>
                     <div className={styles.miniValue}>{container.cpu_usage_percent.toFixed(1)}%</div>
+                    <div className={styles.miniUnit} data-testid={`container-card-state-${containerLabel(container)}`}>
+                      {container.reporting === false
+                        ? 'not reporting'
+                        : container.crash_looping
+                          ? 'crash looping'
+                          : (container.restarts_last_hour ?? 0) > 0
+                            ? `${container.restarts_last_hour} restarts`
+                            : `up ${formatUptime(container.uptime_seconds)}`}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -623,7 +635,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           cpu: c.cpu_usage_percent
                         }))}>
                           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
@@ -649,7 +661,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           throttled: c.cpu_throttled_seconds
                         }))}>
                           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
@@ -682,7 +694,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           const defaultValues: Record<string, number> = {}
                           cpuSeries.forEach(s => {
                             if (s.labels?.name) {
-                              const shortName = s.labels.name.replace('ubuntu-', '').replace('-1', '')
+                              const shortName = containerDisplayName(s.labels.name)
                               defaultValues[shortName] = 0
                             }
                           })
@@ -696,7 +708,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                               const key = roundedTime.toISOString()
                               const existing = dataMap.get(key) || {}
                               if (s.labels?.name) {
-                                const shortName = s.labels.name.replace('ubuntu-', '').replace('-1', '')
+                                const shortName = containerDisplayName(s.labels.name)
                                 existing[shortName] = v.value
                               }
                               dataMap.set(key, existing)
@@ -718,7 +730,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           <Tooltip content={<SortedTooltip />} />
                           {containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage' && s.labels?.name).map((s, i) => {
                             const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = s.labels!.name.replace('ubuntu-', '').replace('-1', '')
+                            const shortName = containerDisplayName(s.labels!.name)
                             return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
                           })}
                         </LineChart>
@@ -742,7 +754,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           memory: c.memory_usage_percent
                         }))}>
                           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
@@ -768,7 +780,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           used: c.memory_usage_bytes / (1024 * 1024),
                           limit: c.memory_limit_bytes / (1024 * 1024)
                         }))}>
@@ -803,7 +815,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           const defaultValues: Record<string, number> = {}
                           memSeries.forEach(s => {
                             if (s.labels?.name) {
-                              const shortName = s.labels.name.replace('ubuntu-', '').replace('-1', '')
+                              const shortName = containerDisplayName(s.labels.name)
                               defaultValues[shortName] = 0
                             }
                           })
@@ -817,7 +829,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                               const key = roundedTime.toISOString()
                               const existing = dataMap.get(key) || {}
                               if (s.labels?.name) {
-                                const shortName = s.labels.name.replace('ubuntu-', '').replace('-1', '')
+                                const shortName = containerDisplayName(s.labels.name)
                                 existing[shortName] = v.value
                               }
                               dataMap.set(key, existing)
@@ -839,7 +851,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           <Tooltip content={<SortedTooltip />} />
                           {containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent' && s.labels?.name).map((s, i) => {
                             const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = s.labels!.name.replace('ubuntu-', '').replace('-1', '')
+                            const shortName = containerDisplayName(s.labels!.name)
                             return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
                           })}
                         </LineChart>
@@ -863,7 +875,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           rx: c.network_rx_bytes_per_sec / 1024
                         }))}>
                           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
@@ -889,7 +901,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     <ChartErrorBoundary>
                       <ResponsiveContainer width="100%" height={180}>
                         <BarChart data={containerMetrics.containers.map(c => ({
-                          name: c.name.replace('ubuntu-', '').replace('-1', ''),
+                          name: containerLabel(c),
                           tx: c.network_tx_bytes_per_sec / 1024
                         }))}>
                           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
+import ContainerHealthStrip from './ContainerHealth'
 import {
   METRICS_API_URL,
   fetchJson,
   serviceDisplayName,
+  type ContainerDetail,
+  type ContainerStats,
   type ServiceMetricsResponse,
   type TimeSeries,
   type TimeSeriesResponse,
@@ -103,6 +106,7 @@ const SeriesChart = ({
 const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboardProps) => {
   const [scalar, setScalar] = useState<ServiceMetricsResponse | null>(null)
   const [timeseries, setTimeseries] = useState<TimeSeriesResponse | null>(null)
+  const [container, setContainer] = useState<ContainerStats | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
   const [lastService, setLastService] = useState(service)
@@ -113,6 +117,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
     setLastService(service)
     setScalar(null)
     setTimeseries(null)
+    setContainer(null)
   }
 
   useEffect(() => {
@@ -123,14 +128,23 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
     const fetchMetrics = async () => {
       onConnectionStateChange('connecting')
 
-      const [scalarData, seriesData] = await Promise.all([
+      // Container health can't come from the service endpoint: that reports
+      // what the app emitted, which is exactly what a container that won't
+      // start has none of. The dedicated endpoint (MoonBase#1218) resolves by
+      // service name server-side, so this no longer pulls the whole host
+      // payload — every other container's stats — to use one row of it.
+      const [scalarData, seriesData, containerData] = await Promise.all([
         fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}`),
         fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
+        fetchJson<ContainerDetail>(`${METRICS_API_URL}/container/${service}`),
       ])
       if (!active) return
 
       if (scalarData) setScalar(scalarData)
       if (seriesData) setTimeseries(seriesData)
+      // 404s to null — a service with no container is a real state, not a
+      // stale reading, so it must overwrite rather than leave the last one up.
+      setContainer(containerData?.container ?? null)
 
       if (scalarData || seriesData) {
         setLastUpdate(new Date())
@@ -184,6 +198,12 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
       </div>
 
       <div className={styles.metricsGrid}>
+        {/* Above the serving block, and deliberately not behind `standard`:
+            the case this exists for is a container that never got far enough
+            to emit a single metric, which is exactly when `standard` is null
+            and everything below renders empty. */}
+        <ContainerHealthStrip container={container} />
+
         {/* The standard serving block, identical for every service. */}
         {standard && (
           <div className={styles.overviewCards}>

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act, screen, fireEvent } from '@testing-library/react'
+import { render, act, screen, fireEvent, within } from '@testing-library/react'
 import MetricsDashboard from '../MetricsDashboard'
 
 // Mock the recharts library to avoid canvas issues in tests
@@ -139,5 +139,129 @@ describe('MetricsDashboard (host view)', () => {
 
     expect(screen.getByText('Host Metrics')).toBeTruthy()
     expect(screen.queryByText('caddy')).toBeNull()
+  })
+
+  describe('container cards', () => {
+    // Six, because the bug this covers rendered the first four. A fixture of
+    // four or fewer passes either way and would prove nothing.
+    const makeContainer = (service: string, overrides: Record<string, unknown> = {}) => ({
+      name: `ubuntu-${service}-1`,
+      service,
+      cpu_usage_percent: 1.5,
+      cpu_throttled_seconds: 0,
+      memory_usage_bytes: 1048576,
+      memory_limit_bytes: 268435456,
+      memory_usage_percent: 0.4,
+      network_rx_bytes_per_sec: 0,
+      network_tx_bytes_per_sec: 0,
+      restarts_last_hour: 0,
+      uptime_seconds: 7200,
+      crash_looping: false,
+      image: `ghcr.io/muchq/${service}:abc1234`,
+      version: 'abc1234',
+      reporting: true,
+      ...overrides,
+    })
+
+    const withContainers = (containers: unknown[]) => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/host/timeseries/')) {
+          return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(hostTimeseriesResponse)) })
+        }
+        if (url.endsWith('/host')) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(JSON.stringify({ ...hostResponse, containers })),
+          })
+        }
+        return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+      })
+    }
+
+    const settle = async () => {
+      render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      })
+    }
+
+    it('renders every container, not just the first four', async () => {
+      const services = ['caddy', 'postgres', 'prometheus', 'portrait', 'microgpt-serve', 'golf_hub']
+      withContainers(services.map((s) => makeContainer(s)))
+
+      await settle()
+
+      const cards = screen.getByTestId('container-cards')
+      expect(cards.children.length).toBe(6)
+      // Naming the two a slice(0, 4) would drop beats asserting a count alone:
+      // a truncated list still has a length, just the wrong one.
+      for (const service of services) {
+        expect(within(cards).getByText(service)).toBeTruthy()
+      }
+    })
+
+    it('sorts an unhealthy container to the front however the API ordered it', async () => {
+      // Last in the payload, so a render that preserves Prometheus's order
+      // leaves the only container worth looking at at the bottom — and, before
+      // the slice fix, off the page entirely.
+      withContainers([
+        makeContainer('caddy'),
+        makeContainer('postgres'),
+        makeContainer('prometheus'),
+        makeContainer('portrait'),
+        makeContainer('microgpt-serve', { restarts_last_hour: 2 }),
+        makeContainer('golf_hub', { crash_looping: true, restarts_last_hour: 47, uptime_seconds: 8 }),
+      ])
+
+      await settle()
+
+      const cards = screen.getByTestId('container-cards')
+      const order = Array.from(cards.children).map((card) => card.querySelector('div')!.textContent)
+      expect(order[0]).toBe('golf_hub')
+      expect(order[1]).toBe('microgpt-serve')
+      expect(screen.getByTestId('container-card-state-golf_hub').textContent).toBe('crash looping')
+      expect(screen.getByTestId('container-card-state-microgpt-serve').textContent).toBe('2 restarts')
+      expect(screen.getByTestId('container-card-state-caddy').textContent).toBe('up 2h')
+    })
+
+    it('marks a non-reporting container instead of rendering it as up', async () => {
+      // Zeroes from a failed cAdvisor query are indistinguishable from a
+      // container that simply has not restarted; only `reporting` separates
+      // them, and "up —" is a worse lie than an explicit gap.
+      withContainers([makeContainer('caddy', { reporting: false, restarts_last_hour: 0, uptime_seconds: 0 })])
+
+      await settle()
+
+      expect(screen.getByTestId('container-card-state-caddy').textContent).toBe('not reporting')
+    })
+
+    it('labels a container by its compose service, not by parsing the name', async () => {
+      // The project prefix is `ubuntu-` on the deployed host but the directory
+      // name under local_deploy.sh, so name-parsing is a guess that happens to
+      // be right in production. A fixture prefixed `ubuntu-` would pass either
+      // way; this one only passes if the label is what's rendered.
+      //
+      // The `-10` is the second trap: the old `.replace('-1', '')` cut the
+      // first literal "-1" anywhere in the string, giving `caddy0`.
+      withContainers([{ ...makeContainer('caddy'), name: 'moonbase-caddy-10' }])
+
+      await settle()
+
+      const cards = screen.getByTestId('container-cards')
+      expect(within(cards).getByText('caddy')).toBeTruthy()
+      expect(within(cards).queryByText('moonbase-caddy')).toBeNull()
+      expect(within(cards).queryByText('caddy0')).toBeNull()
+    })
+
+    it('falls back to the container name when the service label is absent', async () => {
+      // A prom_proxy older than MoonBase#1218 sends no `service` field.
+      const legacy: Record<string, unknown> = makeContainer('caddy')
+      delete legacy.service
+      withContainers([legacy])
+
+      await settle()
+
+      expect(within(screen.getByTestId('container-cards')).getByText('caddy')).toBeTruthy()
+    })
   })
 })

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -44,18 +44,44 @@ const timeseriesResponse = {
   ],
 }
 
+// A healthy container, with the fields MoonBase#1218 added. Overrides let each
+// test state only the fields it is actually about.
+const containerDetail = (overrides: Record<string, unknown> = {}) => ({
+  timestamp: new Date().toISOString(),
+  container: {
+    name: 'ubuntu-golf_hub-1',
+    service: 'golf_hub',
+    cpu_usage_percent: 3.5,
+    cpu_throttled_seconds: 0,
+    memory_usage_bytes: 100,
+    memory_limit_bytes: 1000,
+    memory_usage_percent: 10,
+    network_rx_bytes_per_sec: 0,
+    network_tx_bytes_per_sec: 0,
+    restarts_last_hour: 0,
+    uptime_seconds: 7200,
+    crash_looping: false,
+    image: 'ghcr.io/muchq/golf_hub:abc1234',
+    version: 'abc1234',
+    reporting: true,
+    ...overrides,
+  },
+})
+
+const ok = (body: unknown) => Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
+const notFound = () => Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+
 describe('ServiceDashboard', () => {
   let mockFetch: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     mockFetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes('/service/golf_hub/timeseries/')) {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(timeseriesResponse)) })
-      }
-      if (url.endsWith('/service/golf_hub')) {
-        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(scalarResponse)) })
-      }
-      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+      if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
+      if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+      // Keyed on the exact name so a request for the wrong container 404s
+      // rather than being answered with golf_hub's stats.
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
     })
     globalThis.fetch = mockFetch as unknown as typeof fetch
   })
@@ -171,5 +197,147 @@ describe('ServiceDashboard', () => {
     expect(onConnectionStateChange).toHaveBeenCalledWith('failed')
     expect(screen.getByText('Serving')).toBeTruthy()
     expect(screen.getAllByText('No data available').length).toBeGreaterThan(0)
+  })
+
+  describe('container health', () => {
+    const renderAndSettle = async (service = 'golf_hub') => {
+      render(<ServiceDashboard service={service} onConnectionStateChange={vi.fn()} />)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      })
+      return mockFetch.mock.calls.map((call) => String(call[0]))
+    }
+
+    it('reads health from the per-container endpoint instead of the whole host payload', async () => {
+      const urls = await renderAndSettle()
+
+      expect(urls.some((url) => url.endsWith('/container/golf_hub'))).toBe(true)
+      // The point of the rewiring: the page used to pull every container's
+      // stats and keep one row. Asserting the absence is what makes this test
+      // fail against the previous implementation rather than pass either way.
+      expect(urls.some((url) => url.endsWith('/host'))).toBe(false)
+
+      expect(screen.getByTestId('container-state').textContent).toBe('up')
+      expect(screen.getByTestId('container-uptime').textContent).toBe('2h')
+      expect(screen.getByTestId('container-restarts').textContent).toBe('0')
+      expect(screen.getByTestId('container-version').textContent).toBe('abc1234')
+    })
+
+    it('surfaces a crash loop even when the service emits no metrics at all', async () => {
+      // The case the strip exists for. A container that dies during startup
+      // serves nothing, so both service endpoints come back empty and every
+      // panel below renders "no data" — indistinguishable from idle-healthy.
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) {
+          return ok(containerDetail({ crash_looping: true, restarts_last_hour: 47, uptime_seconds: 8 }))
+        }
+        return notFound()
+      })
+
+      await renderAndSettle()
+
+      expect(screen.getByTestId('container-state').textContent).toBe('crash looping')
+      expect(screen.getByTestId('container-restarts').textContent).toBe('47')
+      expect(screen.getByTestId('container-uptime').textContent).toBe('8s')
+      // Proves the strip is not gated on the standard block, which is null here.
+      expect(screen.queryByText('Sessions')).toBeNull()
+    })
+
+    it('reports restarts that have not yet met the crash-loop rule', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) {
+          return ok(containerDetail({ crash_looping: false, restarts_last_hour: 2 }))
+        }
+        return notFound()
+      })
+
+      await renderAndSettle()
+
+      expect(screen.getByTestId('container-state').textContent).toBe('restarting')
+      expect(screen.getByTestId('container-restarts').textContent).toBe('2')
+    })
+
+    it('separates a non-reporting container from a healthy zero', async () => {
+      // cAdvisor returning nothing leaves 0 restarts and 0 uptime, which is
+      // byte-identical to a container that has never restarted. Only the
+      // `reporting` flag tells them apart, so rendering must consult it —
+      // drop that check and this container reads as "up".
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) {
+          return ok(containerDetail({ reporting: false, restarts_last_hour: 0, uptime_seconds: 0 }))
+        }
+        return notFound()
+      })
+
+      await renderAndSettle()
+
+      expect(screen.getByTestId('container-state').textContent).toBe('not reporting')
+      expect(screen.getByTestId('container-uptime').textContent).toBe('—')
+      expect(screen.getByTestId('container-restarts').textContent).toBe('—')
+    })
+
+    it('says unknown when no container backs the service', async () => {
+      // portrait's container endpoint 404s under the default mock.
+      await renderAndSettle('portrait')
+
+      expect(screen.getByTestId('container-state').textContent).toBe('unknown')
+    })
+
+    it('clears the previous service\'s container when switching tabs', async () => {
+      const { rerender } = render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      })
+      expect(screen.getByTestId('container-state').textContent).toBe('up')
+
+      // portrait has no container. Leaving golf_hub's "up" on screen would
+      // report a healthy container for a service that has none.
+      rerender(<ServiceDashboard service="portrait" onConnectionStateChange={vi.fn()} />)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      })
+
+      expect(screen.getByTestId('container-state').textContent).toBe('unknown')
+    })
+
+    it('clears a container that disappears between polls', async () => {
+      // Distinct from the tab switch, which resets during render. Here the
+      // service never changes: the container is removed under it, by a rename
+      // or a compose edit. Keeping the last good reading would report a
+      // healthy container for one that no longer exists — and unlike a blank
+      // panel, a stale "up" doesn't look like missing data.
+      vi.useFakeTimers()
+      try {
+        render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0)
+        })
+        expect(screen.getByTestId('container-state').textContent).toBe('up')
+
+        mockFetch.mockImplementation((url: string) => {
+          if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
+          if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+          return notFound()
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30000)
+        })
+
+        expect(screen.getByTestId('container-state').textContent).toBe('unknown')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('falls back to a dash when the image carries no tag', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) return ok(containerDetail({ image: 'golf_hub', version: '' }))
+        return notFound()
+      })
+
+      await renderAndSettle()
+
+      expect(screen.getByTestId('container-version').textContent).toBe('—')
+    })
   })
 })


### PR DESCRIPTION
Renders the container signal added in MoonBase#1215/#1218. Partially addresses MoonBase#242 (§1, §2, and the running-version half of §4).

## Why

Every panel on the service page is built from `http_server_*` series. A container that dies during startup never binds a port and emits none of them — so a crash-looping service and an idle-but-healthy one render identically: flat lines, no errors, no gap. The page most worth looking at during an incident is the one that looks emptiest.

## Service page

A health strip above the serving block: state, uptime, restarts in the last hour, and the running version.

It is deliberately **not** gated on the standard block being present. The case it exists for is precisely when that block is null and everything below reads "no data".

Four states, kept distinct on purpose:

| state | meaning |
|---|---|
| `unknown` | the container endpoint didn't answer — a 404, or a request that failed. `fetchJson` collapses both to null and can't tell them apart, so this says unknown rather than claiming the container is gone |
| `not reporting` | cAdvisor knows the container but returned no samples |
| `crash looping` | restarts plus a young container |
| `restarting` | restarts that haven't met the crash-loop rule |

`not reporting` can't collapse into `up`: a failed cAdvisor query leaves 0 restarts and 0 uptime, which is byte-identical to a healthy container. The `reporting` field is read as optional so a payload from a prom_proxy older than MoonBase#1218 reads as reporting rather than silently degraded.

Fetches `/metrics/v1/container/{name}`, which resolves by service name server-side, instead of pulling the whole host payload to keep one row of it.

Version comes from the tag on the pinned image, which is per-commit since MoonBase#1210.

## Host page

Was rendering `containers.slice(0, 4)` in Prometheus's order across ~14 containers, so the container worth looking at was the one most likely to be cut. Now renders all of them, sorted so anything crash-looping or restarting comes first, with restarts/uptime/crash-loop on each card.

## Container names

Now taken from the compose service label rather than `.replace('ubuntu-', '').replace('-1', '')`, which was repeated at 13 call sites. That replace was unanchored — it cut the first literal `-1` anywhere, turning `caddy-10` into `caddy0` — and the `ubuntu-` prefix is just the directory name under `local_deploy.sh`, so the parse was a guess that happened to hold in production. The label is a fact; the parse stays as a fallback for older prom_proxy payloads.

`MetricsDashboard`'s private `ContainerStats`, which had none of the health fields, now uses the shared type.

## Testing

306 tests pass; lint and build clean. Green was the weak claim here, so I also ran `scripts/mutation-check` (MoonBase#1219) across all three changed files: 12 mutations, all killed.

Two survived the first pass and are now covered:

- a 404 between polls left the previous container's `up` on screen — a code comment claimed `?? null` handled it, but nothing tested it
- the service-label assertion used an `ubuntu-`-prefixed fixture, where parsing and the label agree, so it passed either way; changed to `moonbase-caddy-10`, the `local_deploy.sh` case the label exists for

## Not included

From MoonBase#242: the dedicated Containers tab (§3), commit/build links and cross-stack version drift (§4 beyond showing the revision), and charting the `container_restarts` series on the host page. The issue's "summary table" doesn't exist in this codebase — the host page has cards and charts only.

Also not included, found during review: the six container line-chart naming sites still call `containerDisplayName` while the cards and bar charts moved to `containerLabel`, so chart series names won't match card names on a host whose compose project isn't `ubuntu-`. Fixing it needs a name→service map built from the host payload, since the timeseries labels don't carry the compose service. The recharts test mock drops `data` and `dataKey`, so none of the chart naming is asserted — mutating those sites leaves the suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_