### PR TITLE
metrics: shorten the pinned SHA on the version card

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -6,6 +6,7 @@ import {
   fetchJson,
   formatUptime,
   serviceDisplayName,
+  shortVersion,
   splitHostTimeseries,
   type ContainerStats,
   type TimeSeriesResponse,
@@ -152,5 +153,26 @@ describe('formatUptime', () => {
     // reads like a fact about a running container.
     expect(formatUptime(0)).toBe('—')
     expect(formatUptime(NaN)).toBe('—')
+  })
+})
+
+describe('shortVersion', () => {
+  it('cuts a full commit SHA to git short form', () => {
+    // What deploys actually pin. 40 unbroken hex characters have no break
+    // opportunity, so rendering them raw overflows the card they sit in.
+    expect(shortVersion('c0bcc5049c30e654c319ae39627a4a8f7800d077')).toBe('c0bcc50')
+  })
+
+  it('leaves anything that is not hex alone', () => {
+    // Cutting these would lose information rather than abbreviate it.
+    expect(shortVersion('v2.1.0-rc.3')).toBe('v2.1.0-rc.3')
+    expect(shortVersion('latest')).toBe('latest')
+    expect(shortVersion('')).toBe('')
+  })
+
+  it('leaves an already-short SHA alone', () => {
+    // Nothing to gain, and re-cutting a 7-char SHA to 7 chars would make the
+    // threshold invisible if it ever changed.
+    expect(shortVersion('abc1234')).toBe('abc1234')
   })
 })

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -102,6 +102,18 @@ export function byHealthThenName(a: ContainerStats, b: ContainerStats): number {
   return containerLabel(a).localeCompare(containerLabel(b))
 }
 
+// Deploys pin images by full commit SHA (MoonBase#1210), so `version` arrives as
+// 40 hex characters — an unbroken string with nowhere to wrap, which paints
+// straight out of its card. Show git's short form instead.
+//
+// Only strings that are actually hex are cut. A semver tag or `latest` is left
+// alone: truncating those would lose information rather than abbreviate it.
+const LONG_SHA = /^[0-9a-f]{12,}$/i
+
+export function shortVersion(version: string): string {
+  return LONG_SHA.test(version) ? version.slice(0, 7) : version
+}
+
 export function formatUptime(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return '—'
   if (seconds < 60) return `${Math.floor(seconds)}s`

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -1,5 +1,5 @@
 import styles from './MetricsDashboard.module.css'
-import { containerLabel, formatUptime, type ContainerStats } from '../api'
+import { containerLabel, formatUptime, shortVersion, type ContainerStats } from '../api'
 
 // Three states a service page can't distinguish on its own. Every panel above
 // this strip is built from http_server_* series, and a container that dies
@@ -65,8 +65,8 @@ export function ContainerHealthStrip({ container }: { container: ContainerStats 
       </div>
       <div className={styles.miniCard}>
         <div className={styles.miniLabel}>Version</div>
-        <div className={styles.miniValue} data-testid="container-version">
-          {container.version || '—'}
+        <div className={styles.miniValue} data-testid="container-version" title={container.version || undefined}>
+          {container.version ? shortVersion(container.version) : '—'}
         </div>
         <div className={styles.miniUnit}>running</div>
       </div>

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -137,6 +137,11 @@
   font-weight: 300;
   color: #66b6ff;
   letter-spacing: -0.3px;
+  /* These cards hold values from the metrics backend, not fixed copy, so a long
+     one must wrap inside its card rather than paint across the page. `anywhere`
+     rather than `break-word` because the values that overflow are unbroken
+     identifiers — image tags, container names — with no break opportunity. */
+  overflow-wrap: anywhere;
 }
 
 .miniUnit {

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -61,8 +61,11 @@ const containerDetail = (overrides: Record<string, unknown> = {}) => ({
     restarts_last_hour: 0,
     uptime_seconds: 7200,
     crash_looping: false,
-    image: 'ghcr.io/muchq/golf_hub:abc1234',
-    version: 'abc1234',
+    // A full 40-char commit SHA, which is what deploys actually pin (the old
+    // `abc1234` fixture was a short SHA the backend never sends, and it hid an
+    // overflow that shipped).
+    image: 'ghcr.io/muchq/golf_hub:c0bcc5049c30e654c319ae39627a4a8f7800d077',
+    version: 'c0bcc5049c30e654c319ae39627a4a8f7800d077',
     reporting: true,
     ...overrides,
   },
@@ -220,7 +223,32 @@ describe('ServiceDashboard', () => {
       expect(screen.getByTestId('container-state').textContent).toBe('up')
       expect(screen.getByTestId('container-uptime').textContent).toBe('2h')
       expect(screen.getByTestId('container-restarts').textContent).toBe('0')
-      expect(screen.getByTestId('container-version').textContent).toBe('abc1234')
+      expect(screen.getByTestId('container-version').textContent).toBe('c0bcc50')
+    })
+
+    it('shortens the pinned commit SHA but keeps the full one on hover', async () => {
+      // Deploys pin by full SHA, so this card gets 40 unbroken hex characters.
+      // Rendered raw it has no break opportunity and paints outside its card,
+      // shoving the strip across the page — which is what shipped in #243.
+      await renderAndSettle()
+
+      const version = screen.getByTestId('container-version')
+      expect(version.textContent).toBe('c0bcc50')
+      // Abbreviating is only acceptable because the full value stays reachable.
+      expect(version.getAttribute('title')).toBe('c0bcc5049c30e654c319ae39627a4a8f7800d077')
+    })
+
+    it('leaves a version that is not a SHA alone', async () => {
+      // Truncating `v2.1.0` to `v2.1.0`'s first 7 chars would be lossless by
+      // luck; truncating a longer tag would not. Only hex gets cut.
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) return ok(containerDetail({ version: 'v2.1.0-rc.3' }))
+        if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+        return ok(timeseriesResponse)
+      })
+      await renderAndSettle()
+
+      expect(screen.getByTestId('container-version').textContent).toBe('v2.1.0-rc.3')
     })
 
     it('surfaces a crash loop even when the service emits no metrics at all', async () => {


### PR DESCRIPTION
Follow-up to #243, fixing a layout bug visible on the deployed Golf Hub page.

## Symptom

The Version card renders the running revision, which on the live page is the full 40-character commit SHA:

```
VERSION
c0bcc5049c30e654c319ae39627a4a8f7800d077
running
```

A hex string has no break opportunity, and `.miniValue` set no wrap rule, so it painted straight out of its card and shoved the rest of the health strip across the page.

## Cause

`ContainerHealth.tsx` rendered `container.version` raw. Deploys pin images by full commit SHA (MoonBase#1210), so that field is always 40 characters — the card was only ever going to fit a value the backend doesn't send.

## Fix

- Show git's short form (7 chars) on the card, with the full SHA on the element's `title` so nothing is lost.
- Only hex is cut: `shortVersion` requires the whole string to be 12+ hex characters, so `v2.1.0-rc.3` and `latest` pass through untouched. Truncating those would lose information rather than abbreviate it.
- `overflow-wrap: anywhere` on `.miniValue`. These cards hold values from the metrics backend rather than fixed copy, so the next long one should wrap inside its card instead of reaching the page again.

## Why this shipped green

The fixture. It used `version: 'abc1234'` — a 7-character short SHA the backend never sends — so every assertion agreed with the broken render. The test data was the wrong shape, not the assertions.

It now carries a real 40-char SHA, which means the pre-existing version assertion fails against the old code. Confirmed by mutation rather than assumed: reverting the fix to `{container.version || '—'}` fails 2 tests.

```
AssertionError: expected 'c0bcc5049c30e654c319ae39627a4a8f7800d…' to be 'c0bcc50'
Tests  2 failed | 50 passed (52)
```

## Testing

52 tests pass (3 new in `api.test.ts` for `shortVersion`, 2 new in `ServiceDashboard.test.tsx` covering the short-form render, the `title` fallback, and a non-SHA version). `tsc --noEmit`, eslint, and the production build are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_