### PR TITLE
metrics: Containers tab, restart history, and version deep-links

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -5,7 +5,13 @@ import {
   containerLabel,
   fetchJson,
   formatUptime,
+  buildUrl,
+  commitUrl,
+  containerState,
+  formatBytes,
+  hasDrifted,
   serviceDisplayName,
+  stackVersion,
   shortVersion,
   splitHostTimeseries,
   type ContainerStats,
@@ -174,5 +180,86 @@ describe('shortVersion', () => {
     // Nothing to gain, and re-cutting a 7-char SHA to 7 chars would make the
     // threshold invisible if it ever changed.
     expect(shortVersion('abc1234')).toBe('abc1234')
+  })
+})
+
+describe('containerState', () => {
+  it('separates a container it cannot see from a healthy one', () => {
+    // A failed cAdvisor query leaves 0 restarts and 0 uptime, which is
+    // byte-identical to a healthy container. Only `reporting` tells them apart.
+    expect(containerState(stats({ name: 'a', reporting: false }))).toBe('not reporting')
+    expect(containerState(stats({ name: 'a', reporting: true }))).toBe('up')
+  })
+
+  it('reads a missing reporting field as reporting', () => {
+    // A prom_proxy older than MoonBase#1218 sends no such field; defaulting it
+    // to false would show the whole stack as blind after a UI-only deploy.
+    const legacy = stats({ name: 'a' }) as unknown as Record<string, unknown>
+    delete legacy.reporting
+    expect(containerState(legacy as unknown as ContainerStats)).toBe('up')
+  })
+
+  it('ranks a crash loop above ordinary restart churn', () => {
+    expect(containerState(stats({ name: 'a', crash_looping: true, restarts_last_hour: 5 }))).toBe('crash looping')
+    expect(containerState(stats({ name: 'a', restarts_last_hour: 2 }))).toBe('restarting')
+  })
+})
+
+describe('stackVersion and hasDrifted', () => {
+  const at = (service: string, version: string) => stats({ name: service, service, version })
+
+  it('takes the revision most of the stack is running', () => {
+    const containers = [at('a', 'aaaaaaaaaaaa1'), at('b', 'aaaaaaaaaaaa1'), at('c', 'bbbbbbbbbbbb2')]
+    expect(stackVersion(containers)).toBe('aaaaaaaaaaaa1')
+  })
+
+  it('flags only the container that disagrees', () => {
+    const containers = [at('a', 'aaaaaaaaaaaa1'), at('b', 'aaaaaaaaaaaa1'), at('c', 'bbbbbbbbbbbb2')]
+    const stack = stackVersion(containers)
+    expect(hasDrifted(containers[0], stack)).toBe(false)
+    expect(hasDrifted(containers[2], stack)).toBe(true)
+  })
+
+  it('flags nothing when the stack agrees', () => {
+    const containers = [at('a', 'aaaaaaaaaaaa1'), at('b', 'aaaaaaaaaaaa1')]
+    const stack = stackVersion(containers)
+    expect(containers.every((c) => !hasDrifted(c, stack))).toBe(true)
+  })
+
+  it('ignores upstream tags entirely', () => {
+    // caddy:2-alpine is not pinned per commit, so counting it toward the stack
+    // revision or flagging it against one would misfire on every deploy.
+    const containers = [at('golf_hub', 'aaaaaaaaaaaa1'), at('caddy', '2-alpine'), at('pg', '16')]
+    expect(stackVersion(containers)).toBe('aaaaaaaaaaaa1')
+    expect(hasDrifted(containers[1], 'aaaaaaaaaaaa1')).toBe(false)
+    expect(hasDrifted(containers[2], 'aaaaaaaaaaaa1')).toBe(false)
+  })
+
+  it('has no opinion when nothing is pinned to a commit', () => {
+    expect(stackVersion([at('caddy', '2-alpine'), at('pg', '16')])).toBeNull()
+    expect(hasDrifted(at('caddy', '2-alpine'), null)).toBe(false)
+  })
+})
+
+describe('commit and build links', () => {
+  it('links the full SHA even though the short one is displayed', () => {
+    const sha = 'c0bcc5049c30e654c319ae39627a4a8f7800d077'
+    expect(commitUrl(sha)).toBe(`https://github.com/muchq/MoonBase/commit/${sha}`)
+    expect(buildUrl(sha)).toBe(`https://github.com/muchq/MoonBase/commit/${sha}/checks`)
+    expect(shortVersion(sha)).toBe('c0bcc50')
+  })
+})
+
+describe('formatBytes', () => {
+  it('picks the largest whole unit', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1048576)).toBe('1 MB')
+    expect(formatBytes(1610612736)).toBe('1.5 GB')
+  })
+
+  it('does not run off the end of the unit list', () => {
+    // Memory limits arrive unset as enormous sentinels on some containers.
+    expect(formatBytes(Number.MAX_SAFE_INTEGER)).toContain('TB')
+    expect(formatBytes(0)).toBe('0 B')
   })
 })

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -70,6 +70,19 @@ export interface ContainerStats {
   // False when cAdvisor returned nothing. Without it a failed query leaves
   // zeroes, and zero restarts with zero uptime reads as a healthy container.
   reporting?: boolean
+  // Seconds since cAdvisor last saw the container. Optional for the same
+  // reason as `service`: the UI deploys independently of prom_proxy.
+  last_seen_ago_seconds?: number
+  // Best-effort — absent on cAdvisor builds without the counter, which leaves
+  // it zero and indistinguishable from no kills.
+  oom_events_last_hour?: number
+}
+
+// Every container in the stack, including the infrastructure ones that emit no
+// app metrics and so have no service page at all.
+export interface ContainersResponse {
+  timestamp: string
+  containers: ContainerStats[]
 }
 
 // Single-container response from /metrics/v1/container/{name}.
@@ -93,6 +106,16 @@ export function containerLabel(container: ContainerStats): string {
   return container.service || containerDisplayName(container.name)
 }
 
+// Timeseries labels carry only the raw container name — the compose service
+// label rides on the containers list, not on the series. Charts therefore used
+// to re-derive a name with containerDisplayName while the cards next to them
+// used the label, so the two disagreed on any host whose compose project isn't
+// `ubuntu-`. Build the mapping once from the list and let both read from it.
+export function containerLabelLookup(containers: ContainerStats[]): (name: string) => string {
+  const byName = new Map(containers.map((c) => [c.name, containerLabel(c)]))
+  return (name: string) => byName.get(name) ?? containerDisplayName(name)
+}
+
 // Crash-looping first, then whatever else is restarting, so a failing container
 // can't sit below the fold of a long list.
 export function byHealthThenName(a: ContainerStats, b: ContainerStats): number {
@@ -112,6 +135,81 @@ const LONG_SHA = /^[0-9a-f]{12,}$/i
 
 export function shortVersion(version: string): string {
   return LONG_SHA.test(version) ? version.slice(0, 7) : version
+}
+
+// Only MoonBase images are pinned to a commit. `caddy:2-alpine` and
+// `prom/prometheus:v2.55.0` are upstream tags that have no business being
+// compared against a deploy SHA, so drift detection has to exclude them.
+export function isCommitSha(version: string): boolean {
+  return LONG_SHA.test(version)
+}
+
+const SOURCE_REPO = 'https://github.com/muchq/MoonBase'
+
+// The repo is public, so these need no auth. Display the short SHA, link the
+// full one (MoonBase#1208 §4).
+export function commitUrl(version: string): string {
+  return `${SOURCE_REPO}/commit/${version}`
+}
+
+export function buildUrl(version: string): string {
+  return `${SOURCE_REPO}/commit/${version}/checks`
+}
+
+// The revision most of the stack is running. Drift is measured against peers
+// rather than against the latest published build because the dashboard can't
+// see the registry — what it can see is one container disagreeing with the
+// others, which is exactly the "deploy didn't recreate it" case.
+//
+// Ties resolve to whichever revision appears first in the list; with a stack
+// split evenly across two revisions, either answer flags the other half, and
+// both readings are true.
+export function stackVersion(containers: ContainerStats[]): string | null {
+  const counts = new Map<string, number>()
+  for (const c of containers) {
+    if (c.version && isCommitSha(c.version)) {
+      counts.set(c.version, (counts.get(c.version) ?? 0) + 1)
+    }
+  }
+  let winner: string | null = null
+  let best = 0
+  for (const [version, count] of counts) {
+    if (count > best) {
+      winner = version
+      best = count
+    }
+  }
+  return winner
+}
+
+// A container has drifted when it runs a MoonBase revision that isn't the one
+// the rest of the stack runs. Upstream tags never drift — they aren't deployed
+// per commit — and neither does anything when the whole stack agrees.
+export function hasDrifted(container: ContainerStats, stack: string | null): boolean {
+  if (!stack || !container.version || !isCommitSha(container.version)) return false
+  return container.version !== stack
+}
+
+export type ContainerState = 'up' | 'restarting' | 'crash looping' | 'not reporting'
+
+// The health verdict, in one place so the service strip and the Containers tab
+// can't drift apart about what "up" means.
+//
+// `not reporting` cannot collapse into `up`: a failed cAdvisor query leaves
+// zero restarts and zero uptime, which is byte-identical to a healthy
+// container. `reporting !== false` rather than `=== true` so a payload from a
+// prom_proxy older than MoonBase#1218 reads as reporting rather than degraded.
+export function containerState(container: ContainerStats): ContainerState {
+  if (container.reporting === false) return 'not reporting'
+  if (container.crash_looping) return 'crash looping'
+  return (container.restarts_last_hour ?? 0) > 0 ? 'restarting' : 'up'
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${parseFloat((bytes / Math.pow(1024, i)).toFixed(1))} ${units[i]}`
 }
 
 export function formatUptime(seconds: number): string {

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -1,5 +1,6 @@
 import styles from './MetricsDashboard.module.css'
-import { containerLabel, formatUptime, shortVersion, type ContainerStats } from '../api'
+import ContainerVersion from './ContainerVersion'
+import { containerLabel, containerState, formatUptime, type ContainerStats } from '../api'
 
 // Three states a service page can't distinguish on its own. Every panel above
 // this strip is built from http_server_* series, and a container that dies
@@ -33,13 +34,9 @@ export function ContainerHealthStrip({ container }: { container: ContainerStats 
   // no `reporting` field) reads as reporting rather than silently degraded.
   const reporting = container.reporting !== false
   const restarts = container.restarts_last_hour ?? 0
-  const state = !reporting
-    ? 'not reporting'
-    : container.crash_looping
-      ? 'crash looping'
-      : restarts > 0
-        ? 'restarting'
-        : 'up'
+  // Shared with the Containers tab so the two surfaces can't disagree about
+  // what "up" means for the same container.
+  const state = containerState(container)
 
   return (
     <div className={styles.overviewCards} data-testid="container-health">
@@ -65,8 +62,11 @@ export function ContainerHealthStrip({ container }: { container: ContainerStats 
       </div>
       <div className={styles.miniCard}>
         <div className={styles.miniLabel}>Version</div>
-        <div className={styles.miniValue} data-testid="container-version" title={container.version || undefined}>
-          {container.version ? shortVersion(container.version) : '—'}
+        {/* Drift isn't flagged here: it's a claim about the whole stack, and
+            this page only ever fetches its own container. The Containers tab
+            has the full list and is where that comparison belongs. */}
+        <div className={styles.miniValue} data-testid="container-version">
+          <ContainerVersion version={container.version} />
         </div>
         <div className={styles.miniUnit}>running</div>
       </div>

--- a/src/apps/metrics-systems/components/ContainerVersion.tsx
+++ b/src/apps/metrics-systems/components/ContainerVersion.tsx
@@ -1,0 +1,41 @@
+import styles from './MetricsDashboard.module.css'
+import { buildUrl, commitUrl, isCommitSha, shortVersion } from '../api'
+
+// The running revision, linked to the code and the build that produced it
+// (MoonBase#1208 §4). Deploys pin every image to a commit SHA, so the tag is
+// the revision actually running rather than what the host was told to run.
+//
+// Upstream images (caddy:2-alpine, prom/prometheus:v2.55.0) get no links —
+// there is no MoonBase commit behind them and /commit/2-alpine would 404.
+export const ContainerVersion = ({ version, drifted = false }: { version?: string; drifted?: boolean }) => {
+  if (!version) return <span>—</span>
+  if (!isCommitSha(version)) return <span title={version}>{version}</span>
+
+  return (
+    <span>
+      {/* Short SHA displayed, full SHA linked and on hover. */}
+      <a href={commitUrl(version)} target="_blank" rel="noreferrer" title={version}>
+        {shortVersion(version)}
+      </a>
+      {' · '}
+      <a href={buildUrl(version)} target="_blank" rel="noreferrer">
+        build
+      </a>
+      {/* A container running a revision the rest of the stack isn't means the
+          deploy didn't recreate it — the failure that leaves one service on
+          yesterday's code while every other signal looks healthy. */}
+      {drifted && (
+        <span
+          className={styles.driftFlag}
+          data-testid="version-drift"
+          title="Not the revision the rest of the stack is running"
+        >
+          {' '}
+          drift
+        </span>
+      )}
+    </span>
+  )
+}
+
+export default ContainerVersion

--- a/src/apps/metrics-systems/components/ContainersDashboard.tsx
+++ b/src/apps/metrics-systems/components/ContainersDashboard.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useMemo } from 'react'
+import styles from './MetricsDashboard.module.css'
+import ContainerVersion from './ContainerVersion'
+import {
+  METRICS_API_URL,
+  byHealthThenName,
+  containerLabel,
+  containerState,
+  fetchJson,
+  formatBytes,
+  formatUptime,
+  hasDrifted,
+  stackVersion,
+  type ContainerStats,
+  type ContainersResponse,
+} from '../api'
+
+interface ContainersDashboardProps {
+  onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
+}
+
+// The service pages only cover containers that emit app metrics. Caddy,
+// prometheus, otelcol, cadvisor, postgres and forgejo emit none, so before this
+// tab they appeared nowhere except as unnamed rows in the host page's CPU
+// chart — the infrastructure everything else depends on was the least visible
+// thing on the dashboard.
+const ContainersDashboard = ({ onConnectionStateChange }: ContainersDashboardProps) => {
+  const [containers, setContainers] = useState<ContainerStats[] | null>(null)
+  const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    const fetchContainers = async () => {
+      onConnectionStateChange('connecting')
+      const data = await fetchJson<ContainersResponse>(`${METRICS_API_URL}/containers`)
+      if (!active) return
+
+      if (data) {
+        setContainers(data.containers ?? [])
+        setLastUpdate(new Date())
+        onConnectionStateChange('connected')
+      } else {
+        onConnectionStateChange('failed')
+      }
+    }
+
+    const start = setTimeout(fetchContainers, 0)
+    const interval = setInterval(fetchContainers, 30000)
+    return () => {
+      active = false
+      clearTimeout(start)
+      clearInterval(interval)
+    }
+  }, [onConnectionStateChange])
+
+  // Unhealthy first. The stack runs ~14 containers, so anything ordered by name
+  // puts the one worth looking at halfway down a list nobody scrolls.
+  const sorted = useMemo(() => [...(containers ?? [])].sort(byHealthThenName), [containers])
+  const stack = useMemo(() => stackVersion(containers ?? []), [containers])
+
+  return (
+    <div className={styles.dashboard}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>Containers</h1>
+        <div className={styles.controls}>
+          {lastUpdate && <span className={styles.lastUpdate}>{lastUpdate.toLocaleTimeString()}</span>}
+        </div>
+      </div>
+
+      {containers === null ? (
+        <div className={styles.noData}>Loading containers…</div>
+      ) : sorted.length === 0 ? (
+        <div className={styles.noData}>No containers reported</div>
+      ) : (
+        <div className={styles.section}>
+          <div className={styles.tableScroll}>
+            <table className={styles.containerTable} data-testid="containers-table">
+              <thead>
+                <tr>
+                  <th>Container</th>
+                  <th>State</th>
+                  <th>Uptime</th>
+                  <th>Restarts</th>
+                  <th>Last seen</th>
+                  <th>CPU</th>
+                  <th>Memory</th>
+                  <th>Version</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((container) => (
+                  <ContainerRow key={container.name} container={container} stack={stack} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const ContainerRow = ({ container, stack }: { container: ContainerStats; stack: string | null }) => {
+  const state = containerState(container)
+  const reporting = container.reporting !== false
+  const drifted = hasDrifted(container, stack)
+  const oom = container.oom_events_last_hour ?? 0
+
+  return (
+    <tr data-testid={`container-row-${containerLabel(container)}`} className={state === 'up' ? '' : styles.rowUnhealthy}>
+      <td>{containerLabel(container)}</td>
+      <td data-testid={`container-row-state-${containerLabel(container)}`}>
+        {state}
+        {/* Restart churn says a container is flapping; an OOM count says
+            whether memory is why. Only shown when there is one to report,
+            since a cAdvisor without the counter reads as zero. */}
+        {oom > 0 && <span className={styles.rowNote}> · {oom} OOM</span>}
+      </td>
+      <td>{reporting ? formatUptime(container.uptime_seconds) : '—'}</td>
+      <td>{reporting ? (container.restarts_last_hour ?? 0) : '—'}</td>
+      {/* Answers where uptime can't: uptime describes the current run, so a
+          stopped container has none, while this keeps counting up until
+          Prometheus retention drops the series. */}
+      <td>{formatUptime(container.last_seen_ago_seconds ?? 0)}</td>
+      <td>{reporting ? `${container.cpu_usage_percent.toFixed(1)}%` : '—'}</td>
+      <td>{reporting ? formatBytes(container.memory_usage_bytes) : '—'}</td>
+      <td>
+        <ContainerVersion version={container.version} drifted={drifted} />
+      </td>
+    </tr>
+  )
+}
+
+export default ContainersDashboard

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -441,3 +441,70 @@
   color: rgba(255, 153, 153, 0.7);
   font-style: italic;
 }
+/* Containers tab. The stack runs ~14 containers with eight columns each, which
+   is wider than a phone; the table scrolls inside this wrapper rather than
+   making the page scroll sideways. */
+.tableScroll {
+  overflow-x: auto;
+}
+
+.containerTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.containerTable th {
+  text-align: left;
+  padding: 10px 12px;
+  font-weight: 400;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid rgba(102, 182, 255, 0.2);
+  white-space: nowrap;
+}
+
+.containerTable td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  color: #66b6ff;
+  white-space: nowrap;
+}
+
+.containerTable td:first-child {
+  color: #fff;
+}
+
+.containerTable a {
+  color: #66b6ff;
+  text-decoration: none;
+  border-bottom: 1px dotted rgba(102, 182, 255, 0.4);
+}
+
+.containerTable a:hover {
+  border-bottom-style: solid;
+}
+
+/* Unhealthy rows are already sorted to the top; this is so the boundary between
+   them and the healthy ones is visible without reading every state cell. */
+.rowUnhealthy td {
+  background: rgba(255, 107, 107, 0.06);
+}
+
+.rowUnhealthy td:nth-child(2) {
+  color: #ff6b6b;
+}
+
+.rowNote {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.75rem;
+}
+
+.driftFlag {
+  color: #ffd93d;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
 import {
   METRICS_API_URL,
   byHealthThenName,
-  containerDisplayName,
   containerLabel,
+  containerLabelLookup,
   fetchJson,
   formatUptime,
   splitHostTimeseries,
@@ -125,6 +125,14 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   const [containerTimeseries, setContainerTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+
+  // Charts get their container names from timeseries labels, which carry only
+  // the raw name. Resolving through the containers list keeps every chart
+  // series named the same as the card above it.
+  const seriesLabel = useMemo(
+    () => containerLabelLookup(containerMetrics?.containers ?? []),
+    [containerMetrics],
+  )
 
   useEffect(() => {
     // The flag discards resolutions that land after a range change (or
@@ -694,7 +702,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           const defaultValues: Record<string, number> = {}
                           cpuSeries.forEach(s => {
                             if (s.labels?.name) {
-                              const shortName = containerDisplayName(s.labels.name)
+                              const shortName = seriesLabel(s.labels.name)
                               defaultValues[shortName] = 0
                             }
                           })
@@ -708,7 +716,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                               const key = roundedTime.toISOString()
                               const existing = dataMap.get(key) || {}
                               if (s.labels?.name) {
-                                const shortName = containerDisplayName(s.labels.name)
+                                const shortName = seriesLabel(s.labels.name)
                                 existing[shortName] = v.value
                               }
                               dataMap.set(key, existing)
@@ -730,7 +738,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           <Tooltip content={<SortedTooltip />} />
                           {containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage' && s.labels?.name).map((s, i) => {
                             const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = containerDisplayName(s.labels!.name)
+                            const shortName = seriesLabel(s.labels!.name)
                             return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
                           })}
                         </LineChart>
@@ -815,7 +823,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           const defaultValues: Record<string, number> = {}
                           memSeries.forEach(s => {
                             if (s.labels?.name) {
-                              const shortName = containerDisplayName(s.labels.name)
+                              const shortName = seriesLabel(s.labels.name)
                               defaultValues[shortName] = 0
                             }
                           })
@@ -829,7 +837,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                               const key = roundedTime.toISOString()
                               const existing = dataMap.get(key) || {}
                               if (s.labels?.name) {
-                                const shortName = containerDisplayName(s.labels.name)
+                                const shortName = seriesLabel(s.labels.name)
                                 existing[shortName] = v.value
                               }
                               dataMap.set(key, existing)
@@ -851,7 +859,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                           <Tooltip content={<SortedTooltip />} />
                           {containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent' && s.labels?.name).map((s, i) => {
                             const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = containerDisplayName(s.labels!.name)
+                            const shortName = seriesLabel(s.labels!.name)
                             return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
                           })}
                         </LineChart>
@@ -859,6 +867,68 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                     </ChartErrorBoundary>
                   ) : (
                     <NoDataMessage />
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Container Restarts — the one thing a point-in-time check can't
+                give. The cards above describe the current run, so a loop that
+                started and resolved overnight leaves no trace on them; this is
+                where it shows up. */}
+            <div className={styles.section}>
+              <h2 className={styles.sectionTitle}>Container Restarts</h2>
+              <div className={styles.sectionGrid}>
+                <div className={styles.compactChart}>
+                  <h4>Restarts Over Time</h4>
+                  {containerTimeseries?.series?.some(s => s.metric_name === 'restarts') ? (
+                    <ChartErrorBoundary>
+                      <ResponsiveContainer width="100%" height={180}>
+                        <LineChart data={(() => {
+                          const restartSeries = containerTimeseries.series.filter(s => s.metric_name === 'restarts')
+
+                          const defaultValues: Record<string, number> = {}
+                          restartSeries.forEach(s => {
+                            if (s.labels?.name) defaultValues[seriesLabel(s.labels.name)] = 0
+                          })
+
+                          const dataMap = new Map()
+                          restartSeries.forEach(s => {
+                            s.values?.forEach(v => {
+                              const roundedTime = new Date(Math.round(new Date(v.timestamp).getTime() / 30000) * 30000)
+                              const key = roundedTime.toISOString()
+                              const existing = dataMap.get(key) || {}
+                              if (s.labels?.name) existing[seriesLabel(s.labels.name)] = v.value
+                              dataMap.set(key, existing)
+                            })
+                          })
+
+                          return fillTimeSeriesWithRange(dataMap, defaultValues)
+                        })()}>
+                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                          <XAxis
+                            dataKey="time"
+                            stroke="#888"
+                            fontSize={10}
+                            interval="preserveStartEnd"
+                            domain={['dataMin', 'dataMax']}
+                            type="category"
+                          />
+                          {/* Restarts are counts, so half a restart is not a
+                              reading the axis should offer. */}
+                          <YAxis stroke="#888" fontSize={10} allowDecimals={false} />
+                          {/* Not SortedTooltip: it suffixes every value with %,
+                              which is right for CPU and wrong for a count. */}
+                          <Tooltip />
+                          {containerTimeseries.series.filter(s => s.metric_name === 'restarts' && s.labels?.name).map((s, i) => {
+                            const colors = [COLORS.danger, COLORS.warning, COLORS.primary, COLORS.info, COLORS.success, COLORS.secondary]
+                            return <Line key={i} type="monotone" dataKey={seriesLabel(s.labels!.name)} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
+                          })}
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </ChartErrorBoundary>
+                  ) : (
+                    <NoDataMessage message="No restart data in this window" />
                   )}
                 </div>
               </div>

--- a/src/apps/metrics-systems/components/__tests__/ContainersDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ContainersDashboard.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act, screen, within } from '@testing-library/react'
+import ContainersDashboard from '../ContainersDashboard'
+
+const SHA_A = 'c0bcc5049c30e654c319ae39627a4a8f7800d077'
+const SHA_B = 'ff11aa22bb33cc44dd55ee66ff77aa88bb99cc00'
+
+const makeContainer = (service: string, overrides: Record<string, unknown> = {}) => ({
+  name: `ubuntu-${service}-1`,
+  service,
+  cpu_usage_percent: 1.5,
+  cpu_throttled_seconds: 0,
+  memory_usage_bytes: 1048576,
+  memory_limit_bytes: 268435456,
+  memory_usage_percent: 0.4,
+  network_rx_bytes_per_sec: 0,
+  network_tx_bytes_per_sec: 0,
+  restarts_last_hour: 0,
+  uptime_seconds: 7200,
+  crash_looping: false,
+  last_seen_ago_seconds: 5,
+  oom_events_last_hour: 0,
+  image: `ghcr.io/muchq/${service}:${SHA_A}`,
+  version: SHA_A,
+  reporting: true,
+  ...overrides,
+})
+
+describe('ContainersDashboard', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  const withContainers = (containers: unknown[]) => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.endsWith('/containers')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ timestamp: new Date().toISOString(), containers })),
+        })
+      }
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+  }
+
+  const settle = async () => {
+    render(<ContainersDashboard onConnectionStateChange={() => {}} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+  }
+
+  beforeEach(() => {
+    mockFetch = vi.fn()
+    globalThis.fetch = mockFetch as unknown as typeof fetch
+    withContainers([makeContainer('golf_hub')])
+  })
+
+  it('lists infrastructure containers that have no service page at all', async () => {
+    // The reason this tab exists. Caddy, prometheus and postgres emit no app
+    // metrics, so the catalog never lists them and they appear on no service
+    // page — the infrastructure everything else depends on was invisible.
+    withContainers([
+      makeContainer('golf_hub'),
+      makeContainer('caddy', { image: 'caddy:2-alpine', version: '2-alpine' }),
+      makeContainer('prometheus', { image: 'prom/prometheus:v2.55.0', version: 'v2.55.0' }),
+      makeContainer('postgres', { image: 'postgres:16', version: '16' }),
+    ])
+
+    await settle()
+
+    expect(screen.getByTestId('container-row-caddy')).toBeTruthy()
+    expect(screen.getByTestId('container-row-prometheus')).toBeTruthy()
+    expect(screen.getByTestId('container-row-postgres')).toBeTruthy()
+  })
+
+  it('sorts unhealthy containers to the top', async () => {
+    // ~14 containers means anything ordered by name puts the one worth looking
+    // at halfway down a list nobody scrolls to the bottom of.
+    withContainers([
+      makeContainer('aaa_healthy'),
+      makeContainer('zzz_looping', { crash_looping: true, restarts_last_hour: 5, uptime_seconds: 30 }),
+      makeContainer('mmm_restarting', { restarts_last_hour: 2 }),
+    ])
+
+    await settle()
+
+    const rows = within(screen.getByTestId('containers-table')).getAllByRole('row').slice(1)
+    const labels = rows.map((row) => row.getAttribute('data-testid'))
+    expect(labels).toEqual([
+      'container-row-zzz_looping',
+      'container-row-mmm_restarting',
+      'container-row-aaa_healthy',
+    ])
+  })
+
+  it('shows how stale each container is, which uptime cannot answer', async () => {
+    // A stopped container has no current run, so uptime says nothing; its
+    // last_seen keeps counting up until retention drops the series, which is
+    // what keeps "deployed but down" on the page rather than absent from it.
+    withContainers([makeContainer('golf_hub', { last_seen_ago_seconds: 240 })])
+
+    await settle()
+
+    expect(within(screen.getByTestId('container-row-golf_hub')).getByText('4m')).toBeTruthy()
+  })
+
+  it('flags a container running a revision the rest of the stack is not', async () => {
+    // The deploy-did-not-recreate-it case: every other signal looks healthy
+    // while one service quietly serves yesterday's code.
+    withContainers([
+      makeContainer('golf_hub'),
+      makeContainer('mithril'),
+      makeContainer('portrait', { version: SHA_B, image: `ghcr.io/muchq/portrait:${SHA_B}` }),
+    ])
+
+    await settle()
+
+    expect(within(screen.getByTestId('container-row-portrait')).getByTestId('version-drift')).toBeTruthy()
+    expect(within(screen.getByTestId('container-row-golf_hub')).queryByTestId('version-drift')).toBeNull()
+  })
+
+  it('flags nothing when the whole stack agrees', async () => {
+    withContainers([makeContainer('golf_hub'), makeContainer('mithril'), makeContainer('portrait')])
+
+    await settle()
+
+    expect(screen.queryByTestId('version-drift')).toBeNull()
+  })
+
+  it('never calls an upstream image tag drift', async () => {
+    // caddy:2-alpine is not pinned per commit and never will be, so comparing
+    // it against a deploy SHA would flag it on every single deploy.
+    withContainers([
+      makeContainer('golf_hub'),
+      makeContainer('mithril'),
+      makeContainer('caddy', { image: 'caddy:2-alpine', version: '2-alpine' }),
+    ])
+
+    await settle()
+
+    const caddy = within(screen.getByTestId('container-row-caddy'))
+    expect(caddy.queryByTestId('version-drift')).toBeNull()
+    // And no link either — /commit/2-alpine is a 404 dressed as a useful link.
+    expect(screen.getByTestId('container-row-caddy').querySelector('a')).toBeNull()
+  })
+
+  it('links a pinned revision to its commit and build', async () => {
+    await settle()
+
+    const row = within(screen.getByTestId('container-row-golf_hub'))
+    expect(row.getByText('c0bcc50').getAttribute('href')).toBe(`https://github.com/muchq/MoonBase/commit/${SHA_A}`)
+    expect(row.getByText('build').getAttribute('href')).toBe(
+      `https://github.com/muchq/MoonBase/commit/${SHA_A}/checks`,
+    )
+  })
+
+  it('does not report figures for a container it cannot see', async () => {
+    // A failed cAdvisor query leaves zeros, and 0% CPU on a healthy-looking row
+    // is a claim. The dash says we have no reading rather than a reading of 0.
+    withContainers([makeContainer('golf_hub', { reporting: false, uptime_seconds: 0, restarts_last_hour: 0 })])
+
+    await settle()
+
+    const row = within(screen.getByTestId('container-row-golf_hub'))
+    expect(screen.getByTestId('container-row-state-golf_hub').textContent).toContain('not reporting')
+    expect(row.getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('names the memory cause when cAdvisor reports one', async () => {
+    // Restart churn says a container is flapping; OOM says whether memory is
+    // why — the difference between a bad deploy and an undersized limit.
+    withContainers([makeContainer('golf_hub', { restarts_last_hour: 3, oom_events_last_hour: 2 })])
+
+    await settle()
+
+    expect(screen.getByTestId('container-row-state-golf_hub').textContent).toContain('2 OOM')
+  })
+})

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -2,10 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, act, screen, fireEvent, within } from '@testing-library/react'
 import MetricsDashboard from '../MetricsDashboard'
 
-// Mock the recharts library to avoid canvas issues in tests
+// Mock the recharts library to avoid canvas issues in tests.
+//
+// The naming props are forwarded onto the stubs rather than dropped. `dataKey`
+// is what binds a <Line> to a key in its chart's data, so a mock that discards
+// it cannot tell a correctly-named series from a wrong one — every container
+// name in a chart was unasserted while it did.
+type ChartRow = Record<string, unknown>
+const rowKeys = (data?: ChartRow[]) => JSON.stringify(Object.keys(data?.[0] ?? {}))
+const rowNames = (data?: ChartRow[]) => JSON.stringify((data ?? []).map((d) => d.name))
+
 vi.mock('recharts', () => ({
-  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
-  Line: () => <div data-testid="line" />,
+  LineChart: ({ children, data }: { children: React.ReactNode; data?: ChartRow[] }) => (
+    <div data-testid="line-chart" data-row-keys={rowKeys(data)}>{children}</div>
+  ),
+  Line: ({ dataKey }: { dataKey?: string }) => <div data-testid="line" data-key={dataKey} />,
   AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
   Area: () => <div data-testid="area" />,
   XAxis: () => <div data-testid="x-axis" />,
@@ -13,8 +24,10 @@ vi.mock('recharts', () => ({
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
   Tooltip: () => <div data-testid="tooltip" />,
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
-  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
-  Bar: () => <div data-testid="bar" />,
+  BarChart: ({ children, data }: { children: React.ReactNode; data?: ChartRow[] }) => (
+    <div data-testid="bar-chart" data-row-names={rowNames(data)}>{children}</div>
+  ),
+  Bar: ({ dataKey }: { dataKey?: string }) => <div data-testid="bar" data-key={dataKey} />,
   PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
   Pie: () => <div data-testid="pie" />,
   Cell: () => <div data-testid="cell" />
@@ -251,6 +264,96 @@ describe('MetricsDashboard (host view)', () => {
       expect(within(cards).getByText('caddy')).toBeTruthy()
       expect(within(cards).queryByText('moonbase-caddy')).toBeNull()
       expect(within(cards).queryByText('caddy0')).toBeNull()
+    })
+
+    it('names chart series by the compose service too, not just the cards', async () => {
+      // The cards and the charts take different routes to a name: cards read
+      // the container object, charts read a timeseries label that carries only
+      // the raw name. They disagreed — cards on the label, charts on the parse
+      // — so on any host whose compose project isn't `ubuntu-` the CPU chart's
+      // legend named containers differently from the cards directly above it.
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/host/timeseries/')) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                JSON.stringify({
+                  ...hostTimeseriesResponse,
+                  series: [
+                    {
+                      metric_name: 'container_cpu_usage',
+                      labels: { name: 'moonbase-caddy-10' },
+                      values: [{ timestamp: new Date().toISOString(), value: 5.0 }],
+                    },
+                  ],
+                }),
+              ),
+          })
+        }
+        if (url.endsWith('/host')) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                JSON.stringify({
+                  ...hostResponse,
+                  containers: [{ ...makeContainer('caddy'), name: 'moonbase-caddy-10' }],
+                }),
+              ),
+          })
+        }
+        return Promise.resolve({ ok: false })
+      })
+
+      await settle()
+
+      // dataKey is what binds a <Line> to a column in the chart's data, so it
+      // is the name the legend and tooltip actually show.
+      const keys = screen.getAllByTestId('line').map((el) => el.getAttribute('data-key'))
+      expect(keys).toContain('caddy')
+      expect(keys).not.toContain('moonbase-caddy')
+    })
+
+    it('charts restarts, so a loop that resolved overnight is still visible', async () => {
+      // The cards describe the current run, so a container that flapped at 3am
+      // and recovered shows nothing on them. #1215 ships this series on the
+      // host payload and, until now, nothing rendered it.
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('/host/timeseries/')) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                JSON.stringify({
+                  ...hostTimeseriesResponse,
+                  series: [
+                    {
+                      metric_name: 'container_restarts',
+                      labels: { name: 'ubuntu-golf_hub-1' },
+                      values: [{ timestamp: new Date().toISOString(), value: 3 }],
+                    },
+                  ],
+                }),
+              ),
+          })
+        }
+        if (url.endsWith('/host')) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(JSON.stringify({ ...hostResponse, containers: [makeContainer('golf_hub')] })),
+          })
+        }
+        return Promise.resolve({ ok: false })
+      })
+
+      await settle()
+
+      expect(screen.getByText('Container Restarts')).toBeTruthy()
+      // The only series in this fixture is restarts, so any <Line> at all comes
+      // from the new chart rather than from CPU or memory.
+      const keys = screen.getAllByTestId('line').map((el) => el.getAttribute('data-key'))
+      expect(keys).toContain('golf_hub')
     })
 
     it('falls back to the container name when the service label is absent', async () => {

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act, screen, fireEvent } from '@testing-library/react'
+import { render, act, screen, fireEvent, within } from '@testing-library/react'
 import ServiceDashboard from '../ServiceDashboard'
 
 vi.mock('recharts', () => ({
@@ -223,7 +223,7 @@ describe('ServiceDashboard', () => {
       expect(screen.getByTestId('container-state').textContent).toBe('up')
       expect(screen.getByTestId('container-uptime').textContent).toBe('2h')
       expect(screen.getByTestId('container-restarts').textContent).toBe('0')
-      expect(screen.getByTestId('container-version').textContent).toBe('c0bcc50')
+      expect(within(screen.getByTestId('container-version')).getByText('c0bcc50')).toBeTruthy()
     })
 
     it('shortens the pinned commit SHA but keeps the full one on hover', async () => {
@@ -232,10 +232,39 @@ describe('ServiceDashboard', () => {
       // shoving the strip across the page — which is what shipped in #243.
       await renderAndSettle()
 
-      const version = screen.getByTestId('container-version')
-      expect(version.textContent).toBe('c0bcc50')
+      const commit = within(screen.getByTestId('container-version')).getByText('c0bcc50')
       // Abbreviating is only acceptable because the full value stays reachable.
-      expect(version.getAttribute('title')).toBe('c0bcc5049c30e654c319ae39627a4a8f7800d077')
+      expect(commit.getAttribute('title')).toBe('c0bcc5049c30e654c319ae39627a4a8f7800d077')
+    })
+
+    it('links the running revision to its commit and its build', async () => {
+      // Seeing which revision is live is half the job; the other half is
+      // getting from it to the code and the CI run without hand-assembling a
+      // GitHub URL from a SHA (MoonBase#1208 §4).
+      await renderAndSettle()
+
+      const version = within(screen.getByTestId('container-version'))
+      const sha = 'c0bcc5049c30e654c319ae39627a4a8f7800d077'
+      // The full SHA is what's linked, even though the short one is displayed.
+      expect(version.getByText('c0bcc50').getAttribute('href')).toBe(`https://github.com/muchq/MoonBase/commit/${sha}`)
+      expect(version.getByText('build').getAttribute('href')).toBe(
+        `https://github.com/muchq/MoonBase/commit/${sha}/checks`,
+      )
+    })
+
+    it('does not link an upstream image tag', async () => {
+      // caddy:2-alpine has no MoonBase commit behind it, so /commit/2-alpine
+      // would be a 404 dressed up as a useful link.
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/container/golf_hub')) return ok(containerDetail({ version: '2-alpine' }))
+        if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+        return ok(timeseriesResponse)
+      })
+      await renderAndSettle()
+
+      const version = screen.getByTestId('container-version')
+      expect(version.textContent).toContain('2-alpine')
+      expect(version.querySelector('a')).toBeNull()
     })
 
     it('leaves a version that is not a SHA alone', async () => {

--- a/src/apps/metrics-systems/pages/MetricsPage.tsx
+++ b/src/apps/metrics-systems/pages/MetricsPage.tsx
@@ -4,6 +4,7 @@ import Navigation from '@/shared/components/Navigation'
 import ConnectionStatus, { ConnectionState } from '@/shared/components/nav/ConnectionStatus'
 import RotatingText from '@/shared/components/nav/RotatingText'
 import MetricsDashboard from '../components/MetricsDashboard'
+import ContainersDashboard from '../components/ContainersDashboard'
 import ServiceDashboard from '../components/ServiceDashboard'
 import styles from '../components/MetricsDashboard.module.css'
 import { METRICS_API_URL, fetchJson, serviceDisplayName, type ServiceCatalog } from '../api'
@@ -18,11 +19,20 @@ const metricsFacts = [
 ]
 
 // Pre-overhaul deep links keep working.
+//
+// `containers` used to redirect here to `host`, because the overhaul folded the
+// old container view into the host page and the route had nowhere else to go.
+// It now resolves to the real Containers tab — the old link pointed at a
+// container view, and there is one again, so this is the redirect retiring
+// rather than a link breaking.
 const LEGACY_TABS: Record<string, string> = {
   system: 'host',
-  containers: 'host',
   microgpt: 'microgpt-serve',
 }
+
+// Tabs that aren't services, so the catalog can't vouch for them and the
+// unknown-tab redirect must not bounce them.
+const BUILT_IN_TABS = ['host', 'containers']
 
 const MetricsPage = () => {
   const { tab } = useParams<{ tab: string }>()
@@ -50,7 +60,7 @@ const MetricsPage = () => {
     // Only bounce unknown names once the catalog can actually judge them;
     // if the catalog never loads, unknown names stay in place (an empty
     // service page) rather than guessing at a redirect.
-    if (catalog && tab !== 'host' && !catalog.services.some((s) => s.name === tab)) {
+    if (catalog && !BUILT_IN_TABS.includes(tab) && !catalog.services.some((s) => s.name === tab)) {
       navigate('/metrics/host', { replace: true })
     }
   }, [tab, catalog, navigate])
@@ -61,6 +71,7 @@ const MetricsPage = () => {
 
   const tabs = [
     { id: 'host', label: 'Host' },
+    { id: 'containers', label: 'Containers' },
     ...(catalog?.services ?? []).map((service) => ({
       id: service.name,
       label: serviceDisplayName(service.name),
@@ -82,6 +93,8 @@ const MetricsPage = () => {
       </div>
       {activeTab === 'host' ? (
         <MetricsDashboard onConnectionStateChange={handleConnectionStateChange} />
+      ) : activeTab === 'containers' ? (
+        <ContainersDashboard onConnectionStateChange={handleConnectionStateChange} />
       ) : (
         <ServiceDashboard service={activeTab} onConnectionStateChange={handleConnectionStateChange} />
       )}

--- a/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
+++ b/src/apps/metrics-systems/pages/__tests__/MetricsPage.test.tsx
@@ -28,6 +28,29 @@ const catalogResponse = {
   ],
 }
 
+const containersResponse = {
+  timestamp: new Date().toISOString(),
+  containers: [
+    {
+      name: 'ubuntu-caddy-1',
+      service: 'caddy',
+      cpu_usage_percent: 1.0,
+      cpu_throttled_seconds: 0,
+      memory_usage_bytes: 1048576,
+      memory_limit_bytes: 268435456,
+      memory_usage_percent: 0.4,
+      network_rx_bytes_per_sec: 0,
+      network_tx_bytes_per_sec: 0,
+      restarts_last_hour: 0,
+      uptime_seconds: 7200,
+      crash_looping: false,
+      image: 'caddy:2-alpine',
+      version: '2-alpine',
+      reporting: true,
+    },
+  ],
+}
+
 const LocationSpy = () => {
   const location = useLocation()
   return <span data-testid="location">{location.pathname}</span>
@@ -48,6 +71,9 @@ describe('MetricsPage', () => {
       if (url.endsWith('/services')) {
         return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(catalogResponse)) })
       }
+      if (url.endsWith('/containers')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(containersResponse)) })
+      }
       return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
     }) as unknown as typeof fetch
   })
@@ -59,9 +85,26 @@ describe('MetricsPage', () => {
       await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
+    // Host and Containers are the two tabs that aren't services: the catalog
+    // never lists them, so they're prepended rather than derived from it.
     const tabs = screen.getAllByRole('button').map((button) => button.textContent)
-    expect(tabs.slice(0, 4)).toEqual(['Host', 'Golf Hub', 'MicroGPT', 'Portrait'])
+    expect(tabs.slice(0, 5)).toEqual(['Host', 'Containers', 'Golf Hub', 'MicroGPT', 'Portrait'])
     expect(screen.getByText('Host Metrics')).toBeTruthy()
+  })
+
+  it('resolves the containers tab instead of bouncing it to host', async () => {
+    // `containers` was a legacy redirect to `host` while the overhaul had no
+    // container view. It has one again, so the route resolves rather than
+    // redirecting — and the catalog can't vouch for it, so the unknown-tab
+    // redirect has to know it's built in.
+    renderAt('/metrics/containers')
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/metrics/containers')
+    expect(screen.getByTestId('containers-table')).toBeTruthy()
   })
 
   it('redirects legacy tabs to their new homes', async () => {


### PR DESCRIPTION
Finishes the UI side of #242 — §2 remainder, §3, and §4 — against the container endpoints prom_proxy already serves.

Depends on muchq/MoonBase#1220 for one column; see **Merge order** below.

## Containers tab (§3)

Service pages only cover containers that emit app metrics. Caddy, prometheus, otelcol, cadvisor, postgres and forgejo emit none, so they appeared nowhere except as unnamed rows in the host page's CPU chart — the infrastructure everything else depends on was the least visible thing on the dashboard.

One row per container: state, uptime, restarts, last-seen, CPU, memory, version. Unhealthy sorted to the top, because ~14 containers means anything ordered by name puts the one worth looking at halfway down a list nobody scrolls.

**Route change worth a look:** `/metrics/containers` was a legacy redirect to `host`, from when the overhaul folded the old container view into the host page and the route had nowhere to go. It now resolves to the real tab. The old link pointed at a container view and there is one again, so I read this as the redirect retiring rather than a link breaking — but it is a behaviour change to an existing URL.

## Restart history (§2)

MoonBase#1215 has shipped the `container_restarts` series since day one and nothing rendered it. The cards describe the current run, so a container that flapped at 3am and recovered leaves no trace on them; this chart is where it shows up.

Uses its own tooltip rather than `SortedTooltip`, which suffixes every value with `%` — right for CPU, wrong for a count.

## Version deep-links and drift (§4)

Commit and build links off the running revision: short SHA displayed, full SHA linked.

Drift compares each container against the revision **most of the stack runs** — peers rather than the registry, which the dashboard can't see. That catches the deploy that didn't recreate one container, and won't catch a stack that is uniformly behind.

Upstream tags are excluded from both sides: `caddy:2-alpine` isn't pinned per commit, so `/commit/2-alpine` would be a 404 dressed as a useful link, and comparing it against a deploy SHA would flag it on every single deploy.

Drift is **not** flagged on the service-page strip — it's a claim about the whole stack, and that page only fetches its own container. Fetching the full list there for one badge seemed the wrong trade.

## Two findings from the #243 review, fixed here

This builds directly on both, so they're in scope rather than deferred again:

- Six line-chart naming sites still called `containerDisplayName` while the cards and bar charts used `containerLabel`, so on a host whose compose project isn't `ubuntu-` a chart legend disagreed with the cards directly above it. Timeseries labels carry only the raw container name, so this needed a name→service map built from the containers list, not a rename.
- The recharts test mock dropped `data` and `dataKey`, which is why none of that was caught. It forwards them now, so chart naming is assertable at all.

## Testing

336 tests pass; `tsc --noEmit`, eslint and the production build are clean.

Green is the weak claim, so the four new behaviours were mutation-checked. Each of these fails tests that pass today:

| mutation | result |
|---|---|
| never flag drift | 2 failed |
| count upstream tags toward the stack revision | 1 failed |
| drop the unhealthy-first sort | 1 failed |
| ignore `reporting` (a blind container reads as `up`) | 3 failed |

## Merge order

The Last seen column reads `last_seen_ago_seconds`, which lands in muchq/MoonBase#1220. The field is optional, so nothing breaks if this merges first — the column just renders `—` until the backend deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_