### PR TITLE
metrics: usability pass on the dashboard pages

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -1,19 +1,24 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
+  bucketMs,
   byHealthThenName,
   containerDisplayName,
   containerLabel,
   fetchJson,
+  fillWindow,
   formatUptime,
   buildUrl,
   commitUrl,
   containerState,
   formatBytes,
   hasDrifted,
+  parseDurationMs,
+  seriesWindow,
   serviceDisplayName,
   stackVersion,
   shortVersion,
   splitHostTimeseries,
+  timeTickFormatter,
   type ContainerStats,
   type TimeSeriesResponse,
 } from '../api'
@@ -247,6 +252,93 @@ describe('commit and build links', () => {
     expect(commitUrl(sha)).toBe(`https://github.com/muchq/MoonBase/commit/${sha}`)
     expect(buildUrl(sha)).toBe(`https://github.com/muchq/MoonBase/commit/${sha}/checks`)
     expect(shortVersion(sha)).toBe('c0bcc50')
+  })
+})
+
+describe('parseDurationMs', () => {
+  it('parses bare and Go-composed durations', () => {
+    // Go's Duration.String() writes 5 minutes as "5m0s" and an hour as
+    // "1h0m0s"; hand-written configs send the bare forms.
+    expect(parseDurationMs('30s')).toBe(30_000)
+    expect(parseDurationMs('5m')).toBe(300_000)
+    expect(parseDurationMs('5m0s')).toBe(300_000)
+    expect(parseDurationMs('1h0m0s')).toBe(3_600_000)
+    expect(parseDurationMs('100ms')).toBe(100)
+  })
+
+  it('has no opinion on text with no duration in it', () => {
+    expect(parseDurationMs('')).toBeNull()
+    expect(parseDurationMs(undefined)).toBeNull()
+    expect(parseDurationMs('soon')).toBeNull()
+  })
+})
+
+describe('seriesWindow', () => {
+  const response = (overrides: Record<string, string> = {}) => ({
+    time_range: '1d',
+    start_time: '2026-07-24T00:00:00Z',
+    end_time: '2026-07-25T00:00:00Z',
+    step: '5m0s',
+    ...overrides,
+  })
+
+  it('reads the grid from the response rather than guessing client-side', () => {
+    expect(seriesWindow(response())).toEqual({
+      startMs: Date.parse('2026-07-24T00:00:00Z'),
+      endMs: Date.parse('2026-07-25T00:00:00Z'),
+      stepMs: 300_000,
+    })
+  })
+
+  it('falls back to the known step for the range when the field is unusable', () => {
+    expect(seriesWindow(response({ step: 'garbage' }))?.stepMs).toBe(300_000)
+    expect(seriesWindow(response({ step: '', time_range: '7d' }))?.stepMs).toBe(1_800_000)
+  })
+
+  it('returns null when the window itself is unusable', () => {
+    expect(seriesWindow(null)).toBeNull()
+    expect(seriesWindow(response({ start_time: 'nope' }))).toBeNull()
+    expect(seriesWindow(response({ end_time: '2026-07-24T00:00:00Z' }))).toBeNull()
+    expect(seriesWindow(response({ step: 'garbage', time_range: 'nope' }))).toBeNull()
+  })
+
+  it('coarsens a step that would mint an absurd number of buckets', () => {
+    const window = seriesWindow(response({ step: '1s' }))!
+    expect((window.endMs - window.startMs) / window.stepMs).toBeLessThanOrEqual(4000)
+  })
+})
+
+describe('bucketMs and fillWindow', () => {
+  // One hour at a 5-minute step: 13 buckets.
+  const frame = {
+    startMs: Date.parse('2026-07-24T00:00:00Z'),
+    endMs: Date.parse('2026-07-24T01:00:00Z'),
+    stepMs: 300_000,
+  }
+
+  it('snaps samples onto the grid, including ones slightly off it', () => {
+    expect(bucketMs('2026-07-24T00:05:00Z', frame)).toBe(frame.startMs + 300_000)
+    expect(bucketMs('2026-07-24T00:06:40Z', frame)).toBe(frame.startMs + 300_000)
+  })
+
+  it('spans the whole window, zero-filling buckets with no sample', () => {
+    // The complaint this fixes: select 7d with four hours of samples and the
+    // chart used to show four hours, because only sampled points became rows.
+    const rows = new Map([[bucketMs('2026-07-24T00:10:00Z', frame), { value: 7 }]])
+    const filled = fillWindow(frame, rows, { value: 0 })
+    expect(filled.length).toBe(13)
+    expect(filled.filter((row) => row.value === 7).length).toBe(1)
+    expect(filled[0].value).toBe(0)
+    expect(filled[12].value).toBe(0)
+  })
+
+  it('labels ticks with the day only on multi-day windows', () => {
+    // Six ticks all reading "6:35 AM" on a 7d axis identify no day at all.
+    const dayless = timeTickFormatter(frame)(frame.startMs)
+    const wide = { ...frame, endMs: frame.startMs + 7 * 86_400_000 }
+    const dayful = timeTickFormatter(wide)(frame.startMs)
+    expect(dayful).toContain(dayless)
+    expect(dayful.length).toBeGreaterThan(dayless.length)
   })
 })
 

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -237,6 +237,86 @@ export interface TimeSeriesResponse {
   series: TimeSeries[]
 }
 
+// Go's Duration.String() emits "30s", "5m0s", "1h0m0s"; hand-written configs
+// may send bare "5m". Sum every number+unit pair; null when nothing matches.
+export function parseDurationMs(text: string | undefined): number | null {
+  if (!text) return null
+  const matches = [...text.matchAll(/(\d+(?:\.\d+)?)(ms|h|m|s)/g)]
+  if (!matches.length) return null
+  const unitMs: Record<string, number> = { h: 3600000, m: 60000, s: 1000, ms: 1 }
+  return matches.reduce((total, match) => total + Number(match[1]) * unitMs[match[2]], 0)
+}
+
+// What the proxy's step is expected to be per range, for payloads whose step
+// field is missing or unparseable.
+const FALLBACK_STEP_MS: Record<string, number> = {
+  '30m': 30_000,
+  '1d': 5 * 60_000,
+  '7d': 30 * 60_000,
+}
+
+export interface SeriesWindow {
+  startMs: number
+  endMs: number
+  stepMs: number
+}
+
+// The bucket grid the API actually answered for. A chart that plots only the
+// samples it got shrinks its axis to wherever data happens to exist — select
+// 7d with four hours of samples and the graph shows four hours. Everything
+// here comes from the response so the grid matches the samples' own alignment
+// rather than a client-side guess anchored to "now".
+export function seriesWindow(
+  response: Pick<TimeSeriesResponse, 'start_time' | 'end_time' | 'step' | 'time_range'> | null,
+): SeriesWindow | null {
+  if (!response) return null
+  const startMs = Date.parse(response.start_time)
+  const endMs = Date.parse(response.end_time)
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return null
+  let stepMs = parseDurationMs(response.step) ?? FALLBACK_STEP_MS[response.time_range] ?? 0
+  if (stepMs <= 0) return null
+  // Backstop: a pathologically small step would mint tens of thousands of
+  // buckets and stall the chart. Coarsen rather than refuse to draw.
+  while ((endMs - startMs) / stepMs > 4000) stepMs *= 2
+  return { startMs, endMs, stepMs }
+}
+
+// Snap a sample onto the window's grid so filling can key on exact bucket
+// times instead of hoping timestamps line up.
+export function bucketMs(timestamp: string, window: SeriesWindow): number {
+  return window.startMs + Math.round((Date.parse(timestamp) - window.startMs) / window.stepMs) * window.stepMs
+}
+
+// Six ticks that all say "6:35 AM" identify no day at all, so multi-day
+// windows carry the date in the label.
+export function timeTickFormatter(window: SeriesWindow): (ms: number) => string {
+  const multiDay = window.endMs - window.startMs > 24 * 3600 * 1000
+  return (ms: number) => {
+    const date = new Date(ms)
+    const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    if (!multiDay) return time
+    return `${date.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${time}`
+  }
+}
+
+// One row per bucket across the whole window, missing buckets taking
+// `defaults` (zeroes), so the x-axis always spans the range the user selected.
+export function fillWindow<T extends Record<string, number | string>>(
+  window: SeriesWindow,
+  rows: Map<number, Partial<T>>,
+  defaults: T,
+): Array<T & { time: string; timeMs: number }> {
+  const format = timeTickFormatter(window)
+  const filled: Array<T & { time: string; timeMs: number }> = []
+  for (let t = window.startMs; t <= window.endMs; t += window.stepMs) {
+    filled.push({ ...defaults, ...(rows.get(t) ?? {}), time: format(t), timeMs: t } as T & {
+      time: string
+      timeMs: number
+    })
+  }
+  return filled
+}
+
 // null on any failure — sections render their no-data state instead of
 // tearing the page down.
 export async function fetchJson<T>(url: string): Promise<T | null> {

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -1,8 +1,8 @@
 import styles from './MetricsDashboard.module.css'
 import ContainerVersion from './ContainerVersion'
-import { containerLabel, containerState, formatUptime, type ContainerStats } from '../api'
+import { containerLabel, containerState, formatUptime, type ContainerStats, type ContainerState } from '../api'
 
-// Three states a service page can't distinguish on its own. Every panel above
+// Three states a service page can't distinguish on its own. Every panel below
 // this strip is built from http_server_* series, and a container that dies
 // before it binds a port emits none of them — which looks exactly like an idle
 // but healthy service: flat lines, no errors, no gap.
@@ -15,17 +15,36 @@ import { containerLabel, containerState, formatUptime, type ContainerStats } fro
 //
 // The middle case has to stay distinct from a healthy zero: a failed query
 // leaves 0 restarts and 0 uptime, which would otherwise render as "up".
-export function ContainerHealthStrip({ container }: { container: ContainerStats | null }) {
+//
+// Rendered as a single status line rather than a row of stat cards: this is
+// context for the charts below, not the page's content, so it must not be the
+// biggest thing on screen — while staying loud (red badge) in the one case
+// that matters, a container that is down while every chart looks idle-healthy.
+const STATE_STYLES: Record<ContainerState, string> = {
+  up: 'stateUp',
+  restarting: 'stateWarn',
+  'crash looping': 'stateDown',
+  'not reporting': 'stateUnknown',
+}
+
+export function ContainerHealthStrip({
+  container,
+  loading = false,
+}: {
+  container: ContainerStats | null
+  loading?: boolean
+}) {
   if (!container) {
+    // "loading" before the first fetch settles, "unknown" after: the first is
+    // a promise of an answer, the second is the answer. Flashing "unknown" at
+    // someone during the fetch claims a gap that doesn't exist.
     return (
-      <div className={styles.overviewCards} data-testid="container-health">
-        <div className={styles.miniCard}>
-          <div className={styles.miniLabel}>Container</div>
-          <div className={styles.miniValue} data-testid="container-state">
-            unknown
-          </div>
-          <div className={styles.miniUnit}>no data</div>
-        </div>
+      <div className={styles.statusStrip} data-testid="container-health">
+        <span className={styles.statusLabel}>Container</span>
+        <span className={`${styles.statusState} ${styles.stateUnknown}`} data-testid="container-state">
+          {loading ? 'loading' : 'unknown'}
+        </span>
+        {!loading && <span className={styles.statusItem}>no data from the metrics API</span>}
       </div>
     )
   }
@@ -39,37 +58,27 @@ export function ContainerHealthStrip({ container }: { container: ContainerStats 
   const state = containerState(container)
 
   return (
-    <div className={styles.overviewCards} data-testid="container-health">
-      <div className={styles.miniCard}>
-        <div className={styles.miniLabel}>Container</div>
-        <div className={styles.miniValue} data-testid="container-state">
-          {state}
-        </div>
-        <div className={styles.miniUnit}>{containerLabel(container)}</div>
-      </div>
-      <div className={styles.miniCard}>
-        <div className={styles.miniLabel}>Uptime</div>
-        <div className={styles.miniValue} data-testid="container-uptime">
-          {reporting ? formatUptime(container.uptime_seconds) : '—'}
-        </div>
-      </div>
-      <div className={styles.miniCard}>
-        <div className={styles.miniLabel}>Restarts</div>
-        <div className={styles.miniValue} data-testid="container-restarts">
-          {reporting ? restarts : '—'}
-        </div>
-        <div className={styles.miniUnit}>last hour</div>
-      </div>
-      <div className={styles.miniCard}>
-        <div className={styles.miniLabel}>Version</div>
+    <div className={styles.statusStrip} data-testid="container-health">
+      <span className={styles.statusLabel}>Container</span>
+      <span className={`${styles.statusState} ${styles[STATE_STYLES[state]]}`} data-testid="container-state">
+        {state}
+      </span>
+      <span className={styles.statusItem}>{containerLabel(container)}</span>
+      <span className={styles.statusItem}>
+        uptime <span data-testid="container-uptime">{reporting ? formatUptime(container.uptime_seconds) : '—'}</span>
+      </span>
+      <span className={styles.statusItem}>
+        <span data-testid="container-restarts">{reporting ? restarts : '—'}</span> restarts last hour
+      </span>
+      <span className={styles.statusItem}>
         {/* Drift isn't flagged here: it's a claim about the whole stack, and
             this page only ever fetches its own container. The Containers tab
             has the full list and is where that comparison belongs. */}
-        <div className={styles.miniValue} data-testid="container-version">
+        running{' '}
+        <span data-testid="container-version">
           <ContainerVersion version={container.version} />
-        </div>
-        <div className={styles.miniUnit}>running</div>
-      </div>
+        </span>
+      </span>
     </div>
   )
 }

--- a/src/apps/metrics-systems/components/ContainersDashboard.tsx
+++ b/src/apps/metrics-systems/components/ContainersDashboard.tsx
@@ -59,8 +59,11 @@ const ContainersDashboard = ({ onConnectionStateChange }: ContainersDashboardPro
   const sorted = useMemo(() => [...(containers ?? [])].sort(byHealthThenName), [containers])
   const stack = useMemo(() => stackVersion(containers ?? []), [containers])
 
+  // No .dashboard wrapper here: MetricsPage already provides it, and nesting a
+  // second one doubled the 80px nav padding on this tab alone. The grid wrapper
+  // caps the table at the same width as the other tabs' content.
   return (
-    <div className={styles.dashboard}>
+    <div>
       <div className={styles.header}>
         <h1 className={styles.title}>Containers</h1>
         <div className={styles.controls}>
@@ -68,35 +71,37 @@ const ContainersDashboard = ({ onConnectionStateChange }: ContainersDashboardPro
         </div>
       </div>
 
-      {containers === null ? (
-        <div className={styles.noData}>Loading containers…</div>
-      ) : sorted.length === 0 ? (
-        <div className={styles.noData}>No containers reported</div>
-      ) : (
-        <div className={styles.section}>
-          <div className={styles.tableScroll}>
-            <table className={styles.containerTable} data-testid="containers-table">
-              <thead>
-                <tr>
-                  <th>Container</th>
-                  <th>State</th>
-                  <th>Uptime</th>
-                  <th>Restarts</th>
-                  <th>Last seen</th>
-                  <th>CPU</th>
-                  <th>Memory</th>
-                  <th>Version</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((container) => (
-                  <ContainerRow key={container.name} container={container} stack={stack} />
-                ))}
-              </tbody>
-            </table>
+      <div className={styles.metricsGrid}>
+        {containers === null ? (
+          <div className={styles.noData}>Loading containers…</div>
+        ) : sorted.length === 0 ? (
+          <div className={styles.noData}>No containers reported</div>
+        ) : (
+          <div className={styles.section}>
+            <div className={styles.tableScroll}>
+              <table className={styles.containerTable} data-testid="containers-table">
+                <thead>
+                  <tr>
+                    <th>Container</th>
+                    <th>State</th>
+                    <th>Uptime</th>
+                    <th>Restarts</th>
+                    <th>Last seen</th>
+                    <th>CPU</th>
+                    <th>Memory</th>
+                    <th>Version</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map((container) => (
+                    <ContainerRow key={container.name} container={container} stack={stack} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -10,7 +10,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 30px;
+  /* Same cap as .metricsGrid — on wide screens the title used to drift to the
+     viewport edge while the content stayed centered under it. */
+  max-width: 1400px;
+  margin: 0 auto 30px;
   padding: 0 10px;
 }
 
@@ -54,16 +57,20 @@
   letter-spacing: 0.3px;
 }
 
-/* Tab Navigation */
+/* Tab Navigation. Sized to its tabs rather than a fixed 400px — the bar holds
+   host + containers + one tab per catalog service, and a hard cap squeezed
+   five-plus tabs into wrapping, truncating labels. */
 .tabNavigation {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   margin-bottom: 30px;
   gap: 0;
   background: rgba(26, 31, 53, 0.4);
   border-radius: 8px;
   padding: 4px;
-  max-width: 400px;
+  width: fit-content;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }
@@ -98,15 +105,15 @@
   background: rgba(102, 182, 255, 0.25) !important;
 }
 
-/* Overview Cards - Top Row */
+/* Overview Cards — stat tile rows inside sections. Full content width so the
+   row lines up with the charts around it; the old 600px centered cap left a
+   narrow floating cluster inside 1400px-wide content. auto-fill keeps tiles at
+   a consistent size instead of stretching a short row across the page. */
 .overviewCards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 15px;
-  margin-bottom: 30px;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
 }
 
 .miniCard {
@@ -147,6 +154,79 @@
 .miniUnit {
   font-size: 0.7rem;
   color: rgba(255, 255, 255, 0.5);
+}
+
+/* Container status strip — one line of context above the charts, not a card
+   cluster competing with them. The state badge stays loud in the one case that
+   matters: a container that is down while every chart reads idle-healthy. */
+.statusStrip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 8px;
+  row-gap: 6px;
+  padding: 10px 14px;
+  margin-bottom: 30px;
+  background: rgba(26, 31, 53, 0.4);
+  border: 1px solid rgba(102, 182, 255, 0.15);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.statusStrip a {
+  color: #66b6ff;
+  text-decoration: none;
+  border-bottom: 1px dotted rgba(102, 182, 255, 0.4);
+}
+
+.statusStrip a:hover {
+  border-bottom-style: solid;
+}
+
+.statusLabel {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.statusState {
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.stateUp {
+  color: #66ff88;
+  background: rgba(102, 255, 136, 0.1);
+  border: 1px solid rgba(102, 255, 136, 0.35);
+}
+
+.stateWarn {
+  color: #ffcc66;
+  background: rgba(255, 204, 102, 0.1);
+  border: 1px solid rgba(255, 204, 102, 0.35);
+}
+
+.stateDown {
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.12);
+  border: 1px solid rgba(255, 107, 107, 0.45);
+}
+
+.stateUnknown {
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.statusItem + .statusItem::before {
+  content: '·';
+  margin-right: 8px;
+  color: rgba(255, 255, 255, 0.3);
 }
 
 /* Main Metrics Grid */
@@ -258,19 +338,17 @@
   }
   
   .tabNavigation {
-    max-width: none;
-    margin: 0 15px 20px 15px;
+    margin: 0 auto 20px;
   }
-  
+
   .tab {
     padding: 10px 16px;
     font-size: 0.85rem;
   }
-  
+
   .overviewCards {
     grid-template-columns: repeat(2, 1fr);
     gap: 10px;
-    max-width: none;
   }
   
   .miniCard {

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -4,11 +4,15 @@ import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
 import {
   METRICS_API_URL,
+  bucketMs,
   byHealthThenName,
   containerLabel,
   containerLabelLookup,
   fetchJson,
+  fillWindow,
+  formatBytes,
   formatUptime,
+  seriesWindow,
   splitHostTimeseries,
   type ContainerStats,
   type TimeSeriesResponse,
@@ -55,14 +59,6 @@ interface HostMetricsResponse {
 
 interface MetricsDashboardProps {
   onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
-}
-
-const formatBytes = (bytes: number) => {
-  if (bytes === 0) return '0 B'
-  const k = 1024
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
 }
 
 // Helper component for no data state
@@ -125,6 +121,10 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   const [containerTimeseries, setContainerTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+  // True until the first fetch settles either way. Empty panels say
+  // "Loading…" during it — flashing "No data available" at someone for the
+  // second before data lands claims a gap that doesn't exist.
+  const [loading, setLoading] = useState(true)
 
   // Charts get their container names from timeseries labels, which carry only
   // the raw name. Resolving through the containers list keeps every chart
@@ -146,6 +146,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
         fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/host/timeseries/${timeRange}`),
       ])
       if (!active) return
+      setLoading(false)
 
       if (hostData) {
         if (hostData.system) setSystemMetrics(hostData.system)
@@ -174,94 +175,71 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
     }
   }, [timeRange, onConnectionStateChange])
 
-  const formatTimestamp = (timestamp: string) => {
-    return new Date(timestamp).toLocaleTimeString()
-  }
+  // The chart grids come from the responses themselves (start/end/step), so a
+  // 7d selection charts 7 days even when samples cover four hours — the
+  // uncovered buckets zero-fill. The old grid was generated client-side from
+  // "now" with 30s rounding, whose keys rarely matched the samples' step
+  // alignment on the wider ranges, silently dropping most of the data.
+  const systemFrame = seriesWindow(systemTimeseries)
+  const containerFrame = seriesWindow(containerTimeseries)
+
+  const emptyMessage = loading ? 'Loading…' : 'No data available'
 
   const getCpuTimeseriesData = () => {
     const cpuSeries = systemTimeseries?.series?.find(s => s.metric_name === 'cpu_utilization')
-    const dataMap = new Map()
+    if (!systemFrame || !cpuSeries?.values?.length) return []
 
-    if (cpuSeries?.values?.length) {
-      cpuSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        dataMap.set(key, { value: Math.max(0, Math.min(100, v.value || 0)) })
-      })
-    }
-
-    return fillTimeSeriesWithRange(dataMap, { value: 0 })
+    const rows = new Map<number, { value: number }>()
+    cpuSeries.values.forEach(v => {
+      rows.set(bucketMs(v.timestamp, systemFrame), { value: Math.max(0, Math.min(100, v.value || 0)) })
+    })
+    return fillWindow(systemFrame, rows, { value: 0 })
   }
 
   const getMemoryTimeseriesData = () => {
     const memorySeries = systemTimeseries?.series?.find(s => s.metric_name === 'memory_utilization')
-    const dataMap = new Map()
+    if (!systemFrame || !memorySeries?.values?.length) return []
 
-    if (memorySeries?.values?.length) {
-      memorySeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        dataMap.set(key, { value: Math.max(0, Math.min(100, v.value || 0)) })
-      })
-    }
-
-    return fillTimeSeriesWithRange(dataMap, { value: 0 })
+    const rows = new Map<number, { value: number }>()
+    memorySeries.values.forEach(v => {
+      rows.set(bucketMs(v.timestamp, systemFrame), { value: Math.max(0, Math.min(100, v.value || 0)) })
+    })
+    return fillWindow(systemFrame, rows, { value: 0 })
   }
 
   const getNetworkTimeseriesData = () => {
     const rxSeries = systemTimeseries?.series?.find(s => s.metric_name === 'network_rx_rate' && s.labels?.device === 'eth0')
     const txSeries = systemTimeseries?.series?.find(s => s.metric_name === 'network_tx_rate' && s.labels?.device === 'eth0')
-    const dataMap = new Map()
+    if (!systemFrame || (!rxSeries?.values?.length && !txSeries?.values?.length)) return []
 
-    if (rxSeries?.values?.length && txSeries?.values?.length) {
-      rxSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        const existing = dataMap.get(key) || { rx: 0, tx: 0 }
-        dataMap.set(key, { ...existing, rx: (v.value || 0) / 1024 })
-      })
-
-      txSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        const existing = dataMap.get(key) || { rx: 0, tx: 0 }
-        dataMap.set(key, { ...existing, tx: (v.value || 0) / 1024 })
-      })
-    }
-
-    return fillTimeSeriesWithRange(dataMap, { rx: 0, tx: 0 })
+    const rows = new Map<number, { rx?: number; tx?: number }>()
+    rxSeries?.values?.forEach(v => {
+      const key = bucketMs(v.timestamp, systemFrame)
+      rows.set(key, { ...rows.get(key), rx: (v.value || 0) / 1024 })
+    })
+    txSeries?.values?.forEach(v => {
+      const key = bucketMs(v.timestamp, systemFrame)
+      rows.set(key, { ...rows.get(key), tx: (v.value || 0) / 1024 })
+    })
+    return fillWindow(systemFrame, rows, { rx: 0, tx: 0 })
   }
-
 
   const getDiskIOData = () => {
     const diskSeries = systemTimeseries?.series?.filter(s => s.metric_name === 'disk_io_rate' && s.labels?.device === 'vda')
     const readSeries = diskSeries?.find(s => s.labels?.direction === 'read')
     const writeSeries = diskSeries?.find(s => s.labels?.direction === 'write')
-    const dataMap = new Map()
+    if (!systemFrame || (!readSeries?.values?.length && !writeSeries?.values?.length)) return []
 
-    if (readSeries?.values?.length && writeSeries?.values?.length) {
-      readSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        const existing = dataMap.get(key) || { read: 0, write: 0 }
-        dataMap.set(key, { ...existing, read: (v.value || 0) / (1024 * 1024) })
-      })
-
-      writeSeries.values.forEach(v => {
-        const timestamp = new Date(v.timestamp)
-        const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-        const key = roundedTime.toISOString()
-        const existing = dataMap.get(key) || { read: 0, write: 0 }
-        dataMap.set(key, { ...existing, write: (v.value || 0) / (1024 * 1024) })
-      })
-    }
-
-    return fillTimeSeriesWithRange(dataMap, { read: 0, write: 0 })
+    const rows = new Map<number, { read?: number; write?: number }>()
+    readSeries?.values?.forEach(v => {
+      const key = bucketMs(v.timestamp, systemFrame)
+      rows.set(key, { ...rows.get(key), read: (v.value || 0) / (1024 * 1024) })
+    })
+    writeSeries?.values?.forEach(v => {
+      const key = bucketMs(v.timestamp, systemFrame)
+      rows.set(key, { ...rows.get(key), write: (v.value || 0) / (1024 * 1024) })
+    })
+    return fillWindow(systemFrame, rows, { read: 0, write: 0 })
   }
 
   const getCpuCoreData = () => {
@@ -293,61 +271,6 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   }
 
 
-
-  const generateFullTimeRange = () => {
-    const now = new Date()
-    let intervalMs: number
-    let numPoints: number
-
-    switch (timeRange) {
-      case '30m':
-        intervalMs = 30 * 1000 // 30-second intervals
-        numPoints = 60 // 30 minutes / 30 seconds
-        break
-      case '1d':
-        intervalMs = 5 * 60 * 1000 // 5-minute intervals
-        numPoints = 288 // 24 hours / 5 minutes
-        break
-      case '7d':
-        intervalMs = 30 * 60 * 1000 // 30-minute intervals
-        numPoints = 336 // 7 days / 30 minutes
-        break
-      default:
-        intervalMs = 30 * 1000
-        numPoints = 60
-    }
-
-    const points = []
-    for (let i = numPoints - 1; i >= 0; i--) {
-      const time = new Date(now.getTime() - i * intervalMs)
-      points.push({
-        time: formatTimestamp(time.toISOString()),
-        timestamp: time.toISOString()
-      })
-    }
-    return points
-  }
-
-  // Generic utility to fill time series data across the full time range
-  const fillTimeSeriesWithRange = <T extends Record<string, number | string>>(
-    seriesMap: Map<string, Partial<T>>,
-    defaultValues: T
-  ): Array<T & { time: string }> => {
-    const fullTimeRange = generateFullTimeRange()
-
-    return fullTimeRange.map(point => {
-      const pointTime = new Date(point.timestamp)
-      const roundedPointTime = new Date(Math.round(pointTime.getTime() / 30000) * 30000)
-      const key = roundedPointTime.toISOString()
-
-      const dataPoint = seriesMap.get(key)
-      return {
-        time: point.time,
-        ...defaultValues,
-        ...(dataPoint || {})
-      } as T & { time: string }
-    })
-  }
 
   const COLORS = {
     primary: '#66b6ff',
@@ -382,40 +305,40 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
 
       {/* Tab Content */}
       <div className={styles.metricsGrid}>
-        <>
-            {/* System Overview Cards */}
-            {systemMetrics && (
-              <div className={styles.overviewCards}>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>CPU</div>
-                  <div className={styles.miniValue}>{(systemMetrics.cpu?.utilization_percent || 0).toFixed(1)}%</div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Memory</div>
-                  <div className={styles.miniValue}>{(systemMetrics.memory?.utilization_percent || 0).toFixed(1)}%</div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Disk</div>
-                  <div className={styles.miniValue}>
-                    {systemMetrics.disk?.[0]?.utilization_percent ? systemMetrics.disk[0].utilization_percent.toFixed(1) : 0}%
-                  </div>
-                </div>
-                <div className={styles.miniCard}>
-                  <div className={styles.miniLabel}>Network</div>
-                  <div className={styles.miniValue}>
-                    {(() => {
-                      const eth0 = systemMetrics.network?.find(n => n.interface === 'eth0')
-                      return eth0 ?
-                        formatBytes((eth0.rx_rate_bytes_per_sec || 0) + (eth0.tx_rate_bytes_per_sec || 0)) + '/s'
-                        : '0 B/s'
-                    })()}
-                  </div>
-                </div>
-              </div>
-            )}
-        {/* System Resources Section */}
+        {/* System Resources Section. The point-in-time cards sit inside the
+            section, under its title, rather than floating above the page as an
+            unlabeled cluster. */}
         <div className={styles.section}>
           <h2 className={styles.sectionTitle}>System Resources</h2>
+          {systemMetrics && (
+            <div className={styles.overviewCards}>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>CPU</div>
+                <div className={styles.miniValue}>{(systemMetrics.cpu?.utilization_percent || 0).toFixed(1)}%</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Memory</div>
+                <div className={styles.miniValue}>{(systemMetrics.memory?.utilization_percent || 0).toFixed(1)}%</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Disk</div>
+                <div className={styles.miniValue}>
+                  {systemMetrics.disk?.[0]?.utilization_percent ? systemMetrics.disk[0].utilization_percent.toFixed(1) : 0}%
+                </div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Network</div>
+                <div className={styles.miniValue}>
+                  {(() => {
+                    const eth0 = systemMetrics.network?.find(n => n.interface === 'eth0')
+                    return eth0 ?
+                      formatBytes((eth0.rx_rate_bytes_per_sec || 0) + (eth0.tx_rate_bytes_per_sec || 0)) + '/s'
+                      : '0 B/s'
+                  })()}
+                </div>
+              </div>
+            </div>
+          )}
           <div className={styles.sectionGrid}>
             {/* CPU Utilization */}
             <div className={styles.compactChart}>
@@ -443,7 +366,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
 
@@ -466,7 +389,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
 
@@ -489,7 +412,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
 
@@ -518,7 +441,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
           </div>
@@ -548,7 +471,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
 
@@ -575,7 +498,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
 
@@ -599,399 +522,400 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage />
+                <NoDataMessage message={emptyMessage} />
               )}
             </div>
           </div>
         </div>
-        </>
 
-        <>
-            {/* Container Overview Cards — every container, not the first four.
-                The host runs more than four, and the truncated list was in
-                arbitrary Prometheus order, so the one container worth looking
-                at was the one most likely to be cut. Sorted so anything
-                crash-looping or restarting sorts to the front. */}
-            {containerMetrics && containerMetrics.containers.length > 0 && (
-              <div className={styles.overviewCards} data-testid="container-cards">
-                {[...containerMetrics.containers].sort(byHealthThenName).map(container => (
-                  <div key={container.name} className={styles.miniCard}>
-                    <div className={styles.miniLabel}>{containerLabel(container)}</div>
-                    <div className={styles.miniValue}>{container.cpu_usage_percent.toFixed(1)}%</div>
-                    <div className={styles.miniUnit} data-testid={`container-card-state-${containerLabel(container)}`}>
-                      {container.reporting === false
-                        ? 'not reporting'
-                        : container.crash_looping
-                          ? 'crash looping'
-                          : (container.restarts_last_hour ?? 0) > 0
-                            ? `${container.restarts_last_hour} restarts`
-                            : `up ${formatUptime(container.uptime_seconds)}`}
-                    </div>
+        {/* Container Overview Cards — every container, not the first four.
+            The host runs more than four, and the truncated list was in
+            arbitrary Prometheus order, so the one container worth looking
+            at was the one most likely to be cut. Sorted so anything
+            crash-looping or restarting sorts to the front. Titled, and the
+            value carries its unit — a bare percentage on an unlabeled card
+            doesn't say what's being measured. */}
+        {containerMetrics && containerMetrics.containers.length > 0 && (
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>Containers</h2>
+            <div className={styles.overviewCards} data-testid="container-cards">
+              {[...containerMetrics.containers].sort(byHealthThenName).map(container => (
+                <div key={container.name} className={styles.miniCard}>
+                  <div className={styles.miniLabel}>{containerLabel(container)}</div>
+                  <div className={styles.miniValue}>
+                    {container.reporting === false ? '—' : `${container.cpu_usage_percent.toFixed(1)}%`}
+                    <span className={styles.miniUnit}> cpu</span>
                   </div>
-                ))}
-              </div>
-            )}
-
-            {/* Container CPU Metrics */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Container CPU Metrics</h2>
-              <div className={styles.sectionGrid}>
-                {/* CPU Usage by Container */}
-                <div className={styles.compactChart}>
-                  <h4>CPU Usage by Container</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          cpu: c.cpu_usage_percent
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 182, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(2)}%`, 'CPU Usage']}
-                          />
-                          <Bar dataKey="cpu" fill={COLORS.primary} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
+                  <div className={styles.miniUnit} data-testid={`container-card-state-${containerLabel(container)}`}>
+                    {container.reporting === false
+                      ? 'not reporting'
+                      : container.crash_looping
+                        ? 'crash looping'
+                        : (container.restarts_last_hour ?? 0) > 0
+                          ? `${container.restarts_last_hour} restarts`
+                          : `up ${formatUptime(container.uptime_seconds)}`}
+                  </div>
                 </div>
+              ))}
+            </div>
+          </div>
+        )}
 
-                {/* CPU Throttling by Container */}
-                <div className={styles.compactChart}>
-                  <h4>CPU Throttling (seconds/sec)</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          throttled: c.cpu_throttled_seconds
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(4)}s/s`, 'Throttled']}
-                          />
-                          <Bar dataKey="throttled" fill={COLORS.danger} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-
-                {/* CPU Usage Over Time */}
-                <div className={styles.compactChart}>
-                  <h4>CPU Usage Over Time</h4>
-                  {containerTimeseries?.series?.find(s => s.metric_name === 'cpu_usage') ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <LineChart data={(() => {
-                          const cpuSeries = containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage')
-                          if (!cpuSeries.length) return []
-
-                          // Build default values object with all container names
-                          const defaultValues: Record<string, number> = {}
-                          cpuSeries.forEach(s => {
-                            if (s.labels?.name) {
-                              const shortName = seriesLabel(s.labels.name)
-                              defaultValues[shortName] = 0
-                            }
-                          })
-
-                          // Build data map with all series
-                          const dataMap = new Map()
-                          cpuSeries.forEach(s => {
-                            s.values?.forEach(v => {
-                              const timestamp = new Date(v.timestamp)
-                              const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-                              const key = roundedTime.toISOString()
-                              const existing = dataMap.get(key) || {}
-                              if (s.labels?.name) {
-                                const shortName = seriesLabel(s.labels.name)
-                                existing[shortName] = v.value
-                              }
-                              dataMap.set(key, existing)
-                            })
-                          })
-
-                          return fillTimeSeriesWithRange(dataMap, defaultValues)
-                        })()}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis
-                            dataKey="time"
-                            stroke="#888"
-                            fontSize={10}
-                            interval="preserveStartEnd"
-                            domain={['dataMin', 'dataMax']}
-                            type="category"
-                          />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
-                          <Tooltip content={<SortedTooltip />} />
-                          {containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage' && s.labels?.name).map((s, i) => {
-                            const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = seriesLabel(s.labels!.name)
-                            return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
-                          })}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-              </div>
+        {/* Container CPU Metrics */}
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Container CPU Metrics</h2>
+          <div className={styles.sectionGrid}>
+            {/* CPU Usage by Container */}
+            <div className={styles.compactChart}>
+              <h4>CPU Usage by Container</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      cpu: c.cpu_usage_percent
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 182, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value) => [`${Number(value).toFixed(2)}%`, 'CPU Usage']}
+                      />
+                      <Bar dataKey="cpu" fill={COLORS.primary} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
             </div>
 
-            {/* Container Memory Metrics */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Container Memory Metrics</h2>
-              <div className={styles.sectionGrid}>
-                {/* Memory Usage by Container */}
-                <div className={styles.compactChart}>
-                  <h4>Memory Usage by Container</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          memory: c.memory_usage_percent
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(1)}%`, 'Memory Usage']}
-                          />
-                          <Bar dataKey="memory" fill={COLORS.success} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-
-                {/* Memory Bytes by Container */}
-                <div className={styles.compactChart}>
-                  <h4>Memory Bytes by Container</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          used: c.memory_usage_bytes / (1024 * 1024),
-                          limit: c.memory_limit_bytes / (1024 * 1024)
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} MB`} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value, name) => [`${Number(value).toFixed(0)} MB`, name === 'used' ? 'Used' : 'Limit']}
-                          />
-                          <Bar dataKey="used" fill={COLORS.danger} />
-                          <Bar dataKey="limit" fill={COLORS.warning} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-
-                {/* Memory Usage Over Time */}
-                <div className={styles.compactChart}>
-                  <h4>Memory Usage Over Time (%)</h4>
-                  {containerTimeseries?.series?.find(s => s.metric_name === 'memory_usage_percent') ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <LineChart data={(() => {
-                          const memSeries = containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent')
-                          if (!memSeries.length) return []
-
-                          // Build default values object with all container names
-                          const defaultValues: Record<string, number> = {}
-                          memSeries.forEach(s => {
-                            if (s.labels?.name) {
-                              const shortName = seriesLabel(s.labels.name)
-                              defaultValues[shortName] = 0
-                            }
-                          })
-
-                          // Build data map with all series
-                          const dataMap = new Map()
-                          memSeries.forEach(s => {
-                            s.values?.forEach(v => {
-                              const timestamp = new Date(v.timestamp)
-                              const roundedTime = new Date(Math.round(timestamp.getTime() / 30000) * 30000)
-                              const key = roundedTime.toISOString()
-                              const existing = dataMap.get(key) || {}
-                              if (s.labels?.name) {
-                                const shortName = seriesLabel(s.labels.name)
-                                existing[shortName] = v.value
-                              }
-                              dataMap.set(key, existing)
-                            })
-                          })
-
-                          return fillTimeSeriesWithRange(dataMap, defaultValues)
-                        })()}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis
-                            dataKey="time"
-                            stroke="#888"
-                            fontSize={10}
-                            interval="preserveStartEnd"
-                            domain={['dataMin', 'dataMax']}
-                            type="category"
-                          />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
-                          <Tooltip content={<SortedTooltip />} />
-                          {containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent' && s.labels?.name).map((s, i) => {
-                            const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
-                            const shortName = seriesLabel(s.labels!.name)
-                            return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
-                          })}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-              </div>
+            {/* CPU Throttling by Container */}
+            <div className={styles.compactChart}>
+              <h4>CPU Throttling (seconds/sec)</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      throttled: c.cpu_throttled_seconds
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 102, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value) => [`${Number(value).toFixed(4)}s/s`, 'Throttled']}
+                      />
+                      <Bar dataKey="throttled" fill={COLORS.danger} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
             </div>
 
-            {/* Container Restarts — the one thing a point-in-time check can't
-                give. The cards above describe the current run, so a loop that
-                started and resolved overnight leaves no trace on them; this is
-                where it shows up. */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Container Restarts</h2>
-              <div className={styles.sectionGrid}>
-                <div className={styles.compactChart}>
-                  <h4>Restarts Over Time</h4>
-                  {containerTimeseries?.series?.some(s => s.metric_name === 'restarts') ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <LineChart data={(() => {
-                          const restartSeries = containerTimeseries.series.filter(s => s.metric_name === 'restarts')
+            {/* CPU Usage Over Time */}
+            <div className={styles.compactChart}>
+              <h4>CPU Usage Over Time</h4>
+              {containerTimeseries?.series?.find(s => s.metric_name === 'cpu_usage') ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <LineChart data={(() => {
+                      const cpuSeries = containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage')
+                      if (!containerFrame || !cpuSeries.length) return []
 
-                          const defaultValues: Record<string, number> = {}
-                          restartSeries.forEach(s => {
-                            if (s.labels?.name) defaultValues[seriesLabel(s.labels.name)] = 0
-                          })
+                      // Build default values object with all container names
+                      const defaultValues: Record<string, number> = {}
+                      cpuSeries.forEach(s => {
+                        if (s.labels?.name) {
+                          const shortName = seriesLabel(s.labels.name)
+                          defaultValues[shortName] = 0
+                        }
+                      })
 
-                          const dataMap = new Map()
-                          restartSeries.forEach(s => {
-                            s.values?.forEach(v => {
-                              const roundedTime = new Date(Math.round(new Date(v.timestamp).getTime() / 30000) * 30000)
-                              const key = roundedTime.toISOString()
-                              const existing = dataMap.get(key) || {}
-                              if (s.labels?.name) existing[seriesLabel(s.labels.name)] = v.value
-                              dataMap.set(key, existing)
-                            })
-                          })
+                      // Build data map with all series
+                      const rows = new Map<number, Record<string, number>>()
+                      cpuSeries.forEach(s => {
+                        s.values?.forEach(v => {
+                          const key = bucketMs(v.timestamp, containerFrame)
+                          const existing = rows.get(key) || {}
+                          if (s.labels?.name) {
+                            const shortName = seriesLabel(s.labels.name)
+                            existing[shortName] = v.value
+                          }
+                          rows.set(key, existing)
+                        })
+                      })
 
-                          return fillTimeSeriesWithRange(dataMap, defaultValues)
-                        })()}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis
-                            dataKey="time"
-                            stroke="#888"
-                            fontSize={10}
-                            interval="preserveStartEnd"
-                            domain={['dataMin', 'dataMax']}
-                            type="category"
-                          />
-                          {/* Restarts are counts, so half a restart is not a
-                              reading the axis should offer. */}
-                          <YAxis stroke="#888" fontSize={10} allowDecimals={false} />
-                          {/* Not SortedTooltip: it suffixes every value with %,
-                              which is right for CPU and wrong for a count. */}
-                          <Tooltip />
-                          {containerTimeseries.series.filter(s => s.metric_name === 'restarts' && s.labels?.name).map((s, i) => {
-                            const colors = [COLORS.danger, COLORS.warning, COLORS.primary, COLORS.info, COLORS.success, COLORS.secondary]
-                            return <Line key={i} type="monotone" dataKey={seriesLabel(s.labels!.name)} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
-                          })}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage message="No restart data in this window" />
-                  )}
-                </div>
-              </div>
+                      return fillWindow(containerFrame, rows, defaultValues)
+                    })()}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis
+                        dataKey="time"
+                        stroke="#888"
+                        fontSize={10}
+                        interval="preserveStartEnd"
+                        domain={['dataMin', 'dataMax']}
+                        type="category"
+                      />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
+                      <Tooltip content={<SortedTooltip />} />
+                      {containerTimeseries.series.filter(s => s.metric_name === 'cpu_usage' && s.labels?.name).map((s, i) => {
+                        const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
+                        const shortName = seriesLabel(s.labels!.name)
+                        return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
+                      })}
+                    </LineChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Container Memory Metrics */}
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Container Memory Metrics</h2>
+          <div className={styles.sectionGrid}>
+            {/* Memory Usage by Container */}
+            <div className={styles.compactChart}>
+              <h4>Memory Usage by Container</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      memory: c.memory_usage_percent
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value) => [`${Number(value).toFixed(1)}%`, 'Memory Usage']}
+                      />
+                      <Bar dataKey="memory" fill={COLORS.success} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
             </div>
 
-            {/* Container Network Metrics */}
-            <div className={styles.section}>
-              <h2 className={styles.sectionTitle}>Container Network Metrics</h2>
-              <div className={styles.sectionGrid}>
-                {/* Network RX by Container */}
-                <div className={styles.compactChart}>
-                  <h4>Network Receive (KB/s)</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          rx: c.network_rx_bytes_per_sec / 1024
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} KB/s`} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(2)} KB/s`, 'RX']}
-                          />
-                          <Bar dataKey="rx" fill={COLORS.success} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-
-                {/* Network TX by Container */}
-                <div className={styles.compactChart}>
-                  <h4>Network Transmit (KB/s)</h4>
-                  {containerMetrics && containerMetrics.containers.length > 0 ? (
-                    <ChartErrorBoundary>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <BarChart data={containerMetrics.containers.map(c => ({
-                          name: containerLabel(c),
-                          tx: c.network_tx_bytes_per_sec / 1024
-                        }))}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
-                          <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
-                          <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} KB/s`} />
-                          <Tooltip
-                            contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 204, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
-                            formatter={(value) => [`${Number(value).toFixed(2)} KB/s`, 'TX']}
-                          />
-                          <Bar dataKey="tx" fill={COLORS.warning} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </ChartErrorBoundary>
-                  ) : (
-                    <NoDataMessage />
-                  )}
-                </div>
-              </div>
+            {/* Memory Bytes by Container */}
+            <div className={styles.compactChart}>
+              <h4>Memory Bytes by Container</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      used: c.memory_usage_bytes / (1024 * 1024),
+                      limit: c.memory_limit_bytes / (1024 * 1024)
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} MB`} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value, name) => [`${Number(value).toFixed(0)} MB`, name === 'used' ? 'Used' : 'Limit']}
+                      />
+                      <Bar dataKey="used" fill={COLORS.danger} />
+                      <Bar dataKey="limit" fill={COLORS.warning} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
             </div>
-        </>
+
+            {/* Memory Usage Over Time */}
+            <div className={styles.compactChart}>
+              <h4>Memory Usage Over Time (%)</h4>
+              {containerTimeseries?.series?.find(s => s.metric_name === 'memory_usage_percent') ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <LineChart data={(() => {
+                      const memSeries = containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent')
+                      if (!containerFrame || !memSeries.length) return []
+
+                      // Build default values object with all container names
+                      const defaultValues: Record<string, number> = {}
+                      memSeries.forEach(s => {
+                        if (s.labels?.name) {
+                          const shortName = seriesLabel(s.labels.name)
+                          defaultValues[shortName] = 0
+                        }
+                      })
+
+                      // Build data map with all series
+                      const rows = new Map<number, Record<string, number>>()
+                      memSeries.forEach(s => {
+                        s.values?.forEach(v => {
+                          const key = bucketMs(v.timestamp, containerFrame)
+                          const existing = rows.get(key) || {}
+                          if (s.labels?.name) {
+                            const shortName = seriesLabel(s.labels.name)
+                            existing[shortName] = v.value
+                          }
+                          rows.set(key, existing)
+                        })
+                      })
+
+                      return fillWindow(containerFrame, rows, defaultValues)
+                    })()}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis
+                        dataKey="time"
+                        stroke="#888"
+                        fontSize={10}
+                        interval="preserveStartEnd"
+                        domain={['dataMin', 'dataMax']}
+                        type="category"
+                      />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value}%`} />
+                      <Tooltip content={<SortedTooltip />} />
+                      {containerTimeseries.series.filter(s => s.metric_name === 'memory_usage_percent' && s.labels?.name).map((s, i) => {
+                        const colors = [COLORS.primary, COLORS.success, COLORS.warning, COLORS.danger, COLORS.info, COLORS.secondary]
+                        const shortName = seriesLabel(s.labels!.name)
+                        return <Line key={i} type="monotone" dataKey={shortName} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
+                      })}
+                    </LineChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Container Restarts — the one thing a point-in-time check can't
+            give. The cards above describe the current run, so a loop that
+            started and resolved overnight leaves no trace on them; this is
+            where it shows up. */}
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Container Restarts</h2>
+          <div className={styles.sectionGrid}>
+            <div className={styles.compactChart}>
+              <h4>Restarts Over Time</h4>
+              {containerTimeseries?.series?.some(s => s.metric_name === 'restarts') ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <LineChart data={(() => {
+                      const restartSeries = containerTimeseries.series.filter(s => s.metric_name === 'restarts')
+                      if (!containerFrame || !restartSeries.length) return []
+
+                      const defaultValues: Record<string, number> = {}
+                      restartSeries.forEach(s => {
+                        if (s.labels?.name) defaultValues[seriesLabel(s.labels.name)] = 0
+                      })
+
+                      const rows = new Map<number, Record<string, number>>()
+                      restartSeries.forEach(s => {
+                        s.values?.forEach(v => {
+                          const key = bucketMs(v.timestamp, containerFrame)
+                          const existing = rows.get(key) || {}
+                          if (s.labels?.name) existing[seriesLabel(s.labels.name)] = v.value
+                          rows.set(key, existing)
+                        })
+                      })
+
+                      return fillWindow(containerFrame, rows, defaultValues)
+                    })()}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis
+                        dataKey="time"
+                        stroke="#888"
+                        fontSize={10}
+                        interval="preserveStartEnd"
+                        domain={['dataMin', 'dataMax']}
+                        type="category"
+                      />
+                      {/* Restarts are counts, so half a restart is not a
+                          reading the axis should offer. */}
+                      <YAxis stroke="#888" fontSize={10} allowDecimals={false} />
+                      {/* Not SortedTooltip: it suffixes every value with %,
+                          which is right for CPU and wrong for a count. */}
+                      <Tooltip />
+                      {containerTimeseries.series.filter(s => s.metric_name === 'restarts' && s.labels?.name).map((s, i) => {
+                        const colors = [COLORS.danger, COLORS.warning, COLORS.primary, COLORS.info, COLORS.success, COLORS.secondary]
+                        return <Line key={i} type="monotone" dataKey={seriesLabel(s.labels!.name)} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
+                      })}
+                    </LineChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={loading ? 'Loading…' : 'No restart data in this window'} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Container Network Metrics */}
+        <div className={styles.section}>
+          <h2 className={styles.sectionTitle}>Container Network Metrics</h2>
+          <div className={styles.sectionGrid}>
+            {/* Network RX by Container */}
+            <div className={styles.compactChart}>
+              <h4>Network Receive (KB/s)</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      rx: c.network_rx_bytes_per_sec / 1024
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} KB/s`} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(102, 255, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value) => [`${Number(value).toFixed(2)} KB/s`, 'RX']}
+                      />
+                      <Bar dataKey="rx" fill={COLORS.success} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
+            </div>
+
+            {/* Network TX by Container */}
+            <div className={styles.compactChart}>
+              <h4>Network Transmit (KB/s)</h4>
+              {containerMetrics && containerMetrics.containers.length > 0 ? (
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart data={containerMetrics.containers.map(c => ({
+                      name: containerLabel(c),
+                      tx: c.network_tx_bytes_per_sec / 1024
+                    }))}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+                      <XAxis dataKey="name" stroke="#888" fontSize={10} angle={-45} textAnchor="end" height={80} />
+                      <YAxis stroke="#888" fontSize={10} tickFormatter={(value) => `${value} KB/s`} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 204, 102, 0.3)', borderRadius: '8px', fontSize: '12px' }}
+                        formatter={(value) => [`${Number(value).toFixed(2)} KB/s`, 'TX']}
+                      />
+                      <Bar dataKey="tx" fill={COLORS.warning} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <NoDataMessage message={emptyMessage} />
+              )}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -5,10 +5,14 @@ import styles from './MetricsDashboard.module.css'
 import ContainerHealthStrip from './ContainerHealth'
 import {
   METRICS_API_URL,
+  bucketMs,
   fetchJson,
+  fillWindow,
+  seriesWindow,
   serviceDisplayName,
   type ContainerDetail,
   type ContainerStats,
+  type SeriesWindow,
   type ServiceMetricsResponse,
   type TimeSeries,
   type TimeSeriesResponse,
@@ -43,39 +47,54 @@ const formatValue = (value: number) => {
 const prettyLabel = (label: string) =>
   label.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
 
-const NoDataMessage = () => <div className={styles.noData}>No data available</div>
+const NoDataMessage = ({ message = 'No data available' }: { message?: string }) => (
+  <div className={styles.noData}>{message}</div>
+)
 
 const SeriesChart = ({
   title,
   series,
+  frame,
   color,
   unit,
   area = false,
   scale = (value: number) => value,
+  emptyMessage,
 }: {
   title: string
   series: TimeSeries | undefined
+  frame: SeriesWindow | null
   color: string
   unit: string
   area?: boolean
   scale?: (value: number) => number
+  emptyMessage?: string
 }) => {
-  const formatTimestamp = (timestamp: string) =>
-    new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-
   if (!series?.values?.length) {
     return (
       <div className={styles.compactChart}>
         <h4>{title}</h4>
-        <NoDataMessage />
+        <NoDataMessage message={emptyMessage} />
       </div>
     )
   }
 
-  const data = series.values.map((v) => ({
-    time: formatTimestamp(v.timestamp),
-    value: scale(Math.max(0, v.value || 0)),
-  }))
+  // The samples cover whatever slice of the window the service was actually up
+  // and scraped for; the chart still spans the range the user selected, with
+  // the uncovered buckets zero-filled, instead of shrinking to fit the data.
+  let data: Array<{ time: string; value: number }>
+  if (frame) {
+    const rows = new Map<number, { value: number }>()
+    series.values.forEach((v) => {
+      rows.set(bucketMs(v.timestamp, frame), { value: scale(Math.max(0, v.value || 0)) })
+    })
+    data = fillWindow(frame, rows, { value: 0 })
+  } else {
+    data = series.values.map((v) => ({
+      time: new Date(v.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      value: scale(Math.max(0, v.value || 0)),
+    }))
+  }
   const ChartComponent = area ? AreaChart : LineChart
 
   return (
@@ -110,6 +129,10 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
   const [lastService, setLastService] = useState(service)
+  // True until the first fetch for this service settles either way. Empty
+  // panels say "Loading…" during it — flashing "No data available" for the
+  // second before data lands claims a gap that doesn't exist.
+  const [loading, setLoading] = useState(true)
 
   // Tab switches drop the previous service's data during render, so a
   // slow fetch can't flash stale numbers under the new title.
@@ -118,6 +141,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
     setScalar(null)
     setTimeseries(null)
     setContainer(null)
+    setLoading(true)
   }
 
   useEffect(() => {
@@ -139,6 +163,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
         fetchJson<ContainerDetail>(`${METRICS_API_URL}/container/${service}`),
       ])
       if (!active) return
+      setLoading(false)
 
       if (scalarData) setScalar(scalarData)
       if (seriesData) setTimeseries(seriesData)
@@ -166,6 +191,8 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const findSeries = (name: string) => timeseries?.series?.find((s) => s.metric_name === name)
   const customSeries = (timeseries?.series ?? []).filter((s) => !STANDARD_SERIES.has(s.metric_name))
   const standard = scalar?.standard
+  const frame = seriesWindow(timeseries)
+  const emptyMessage = loading ? 'Loading…' : undefined
 
   const COLORS = {
     primary: '#66b6ff',
@@ -201,46 +228,49 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
         {/* Above the serving block, and deliberately not behind `standard`:
             the case this exists for is a container that never got far enough
             to emit a single metric, which is exactly when `standard` is null
-            and everything below renders empty. */}
-        <ContainerHealthStrip container={container} />
+            and everything below renders empty. A one-line strip rather than a
+            card cluster — it's context for the page, not the page. */}
+        <ContainerHealthStrip container={container} loading={loading} />
 
-        {/* The standard serving block, identical for every service. */}
-        {standard && (
-          <div className={styles.overviewCards}>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>Req/s</div>
-              <div className={styles.miniValue}>{(standard.rate_per_sec || 0).toFixed(2)}</div>
-            </div>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>Error %</div>
-              <div className={styles.miniValue}>{(standard.error_rate_percent || 0).toFixed(1)}</div>
-            </div>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>Avg ms</div>
-              <div className={styles.miniValue}>{((standard.avg_duration_microseconds || 0) / 1000).toFixed(1)}</div>
-            </div>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>P95 ms</div>
-              <div className={styles.miniValue}>{((standard.p95_duration_microseconds || 0) / 1000).toFixed(1)}</div>
-            </div>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>Active</div>
-              <div className={styles.miniValue}>{(standard.active_requests || 0).toFixed(0)}</div>
-            </div>
-            <div className={styles.miniCard}>
-              <div className={styles.miniLabel}>Total</div>
-              <div className={styles.miniValue}>{formatValue(standard.requests_total || 0)}</div>
-            </div>
-          </div>
-        )}
-
+        {/* The standard serving block, identical for every service. The
+            point-in-time tiles live inside the section, under its title, so
+            the first thing on the page is a labeled unit rather than a
+            free-floating cluster of numbers. */}
         <div className={styles.section}>
           <h2 className={styles.sectionTitle}>Serving</h2>
+          {standard && (
+            <div className={styles.overviewCards}>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Req/s</div>
+                <div className={styles.miniValue}>{(standard.rate_per_sec || 0).toFixed(2)}</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Error %</div>
+                <div className={styles.miniValue}>{(standard.error_rate_percent || 0).toFixed(1)}</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Avg ms</div>
+                <div className={styles.miniValue}>{((standard.avg_duration_microseconds || 0) / 1000).toFixed(1)}</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>P95 ms</div>
+                <div className={styles.miniValue}>{((standard.p95_duration_microseconds || 0) / 1000).toFixed(1)}</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Active</div>
+                <div className={styles.miniValue}>{(standard.active_requests || 0).toFixed(0)}</div>
+              </div>
+              <div className={styles.miniCard}>
+                <div className={styles.miniLabel}>Total</div>
+                <div className={styles.miniValue}>{formatValue(standard.requests_total || 0)}</div>
+              </div>
+            </div>
+          )}
           <div className={styles.sectionGrid}>
-            <SeriesChart title="Request Rate" series={findSeries('request_rate')} color={COLORS.primary} unit="req/s" />
-            <SeriesChart title="Error Rate" series={findSeries('error_rate_percent')} color={COLORS.danger} unit="%" />
-            <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area />
-            <SeriesChart title="Active Requests" series={findSeries('active_requests')} color={COLORS.success} unit="" area />
+            <SeriesChart title="Request Rate" series={findSeries('request_rate')} frame={frame} color={COLORS.primary} unit="req/s" emptyMessage={emptyMessage} />
+            <SeriesChart title="Error Rate" series={findSeries('error_rate_percent')} frame={frame} color={COLORS.danger} unit="%" emptyMessage={emptyMessage} />
+            <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} frame={frame} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area emptyMessage={emptyMessage} />
+            <SeriesChart title="Active Requests" series={findSeries('active_requests')} frame={frame} color={COLORS.success} unit="" area emptyMessage={emptyMessage} />
           </div>
         </div>
 
@@ -272,8 +302,10 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
                   key={series.metric_name}
                   title={prettyLabel(series.metric_name)}
                   series={series}
+                  frame={frame}
                   color={[COLORS.primary, COLORS.info, COLORS.success, COLORS.warning][index % 4]}
                   unit=""
+                  emptyMessage={emptyMessage}
                 />
               ))}
             </div>

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -141,6 +141,16 @@ describe('MetricsDashboard (host view)', () => {
     expect(urls.some((url) => url.endsWith('/host/timeseries/7d'))).toBe(true)
   })
 
+  it('says loading, not "no data", before the first fetch resolves', () => {
+    // A pending fetch is a promise of an answer, not an answer. Every chart
+    // used to flash "No data available" for the second before data landed.
+    mockFetch.mockImplementation(() => new Promise(() => {}))
+    render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
+
+    expect(screen.getAllByText('Loading…').length).toBeGreaterThan(0)
+    expect(screen.queryByText('No data available')).toBeNull()
+  })
+
   it('stays up with empty sections when the API is down', async () => {
     mockFetch.mockImplementation(() => Promise.resolve({ ok: false, text: () => Promise.resolve('') }))
     const onConnectionStateChange = vi.fn()

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -2,10 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, act, screen, fireEvent, within } from '@testing-library/react'
 import ServiceDashboard from '../ServiceDashboard'
 
+// `data` length is forwarded onto the chart stubs: whether a chart spans the
+// full selected window or only the samples it happened to get is precisely a
+// question about how many rows it was given.
 vi.mock('recharts', () => ({
-  LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  LineChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="line-chart" data-row-count={data?.length ?? 0}>{children}</div>
+  ),
   Line: () => <div data-testid="line" />,
-  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  AreaChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="area-chart" data-row-count={data?.length ?? 0}>{children}</div>
+  ),
   Area: () => <div data-testid="area" />,
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
@@ -170,6 +177,34 @@ describe('ServiceDashboard', () => {
     expect(screen.queryByText('Sessions')).toBeNull()
     const urls = mockFetch.mock.calls.map((call) => String(call[0]))
     expect(urls.some((url) => url.endsWith('/service/portrait'))).toBe(true)
+  })
+
+  it('charts the full selected window, not just the buckets with samples', async () => {
+    // The fixture's window is 1 day at a 30s step with a single sample. A
+    // chart that plots only its samples gets one row; the filled grid gets
+    // one per bucket — 86400/30 + 1 — so the x-axis spans the selected range
+    // even when the service was only up for a fraction of it.
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const counts = screen
+      .getAllByTestId('line-chart')
+      .map((chart) => Number(chart.getAttribute('data-row-count')))
+    expect(Math.max(...counts)).toBe(2881)
+  })
+
+  it('says loading, not "no data", before the first fetch resolves', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}))
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+
+    // A pending fetch is a promise of an answer, not an answer. "No data
+    // available" flashing before every load claims a gap that doesn't exist.
+    expect(screen.getAllByText('Loading…').length).toBeGreaterThan(0)
+    expect(screen.queryByText('No data available')).toBeNull()
+    expect(screen.getByTestId('container-state').textContent).toBe('loading')
   })
 
   it('refetches with the selected range', async () => {


### PR DESCRIPTION
Usability and layout fixes for the metrics pages, addressing four reported problems plus one found along the way.

## Charts span the selected window

Two bugs, same symptom. Service-page charts plotted only the samples they received, so selecting 7d with four hours of data drew a four-hour axis. The host page *did* fill, but built its grid client-side from `now` with 30-second rounding — those keys rarely matched the samples' step alignment on 1d/7d, so most real data silently dropped into zeros.

Both now build the grid from the response's own `start_time`/`end_time`/`step` (`seriesWindow`/`bucketMs`/`fillWindow` in `api.ts`, with per-range fallbacks for payloads whose step is missing or unparseable), snap samples onto it, and zero-fill uncovered buckets. Multi-day axes include the date in tick labels — six ticks that all say "6:35 AM" identify no day at all — and the seconds noise is gone.

## Service pages no longer open on a cluster of boxes

- Container health is now a one-line status strip under the title (state badge · service · uptime · restarts · running version), red-badged for crash loops so the container-down-while-charts-look-idle case it exists for stays loud.
- The six standard tiles moved inside the **Serving** section under its heading; the first thing on the page is a labeled unit, with the charts directly below.

## Host page container cards are labeled and aligned

The unlabeled boxes were per-container CPU cards. They now sit under a titled **Containers** section, each value carries a "cpu" unit, and a non-reporting container shows "—" instead of a fabricated 0.0%. Stat-card rows lost their 600px centered cap and align with the 1400px content column like everything else.

## Loading states

Both dashboards track whether the first fetch has settled. Empty panels say "Loading…" until then and "No data available" only once the API actually answered with nothing; the container strip shows a `loading` badge instead of flashing "unknown" before every load.

## Other layout fixes

- Containers tab: dropped the nested `.dashboard` wrapper that doubled the top nav padding on that tab alone, and capped the table at content width like the other tabs.
- Tab bar sizes to its tabs instead of squeezing five of them into a hard 400px cap.
- Page header is width-capped to match content, so the title no longer drifts to the viewport edge on wide screens.

## Testing

- New unit tests for `parseDurationMs`/`seriesWindow`/`bucketMs`/`fillWindow`, a window-span assertion on the service dashboard (single sample in a 1d window → one row per bucket), and loading-state tests for both dashboards.
- Full suite: 348 tests pass; typecheck and lint clean.
- Verified visually against a mock prom_proxy serving a 7d window with only 4h of samples (the reported case) — host, service, and containers pages all render with full-width sections and complete axes.

One judgment call worth a look: missing buckets zero-fill, per the report. That's accurate for rates/counts; for P95 latency a gap technically means "no samples" rather than 0 ms. If gaps are preferred there, the fill helper can emit nulls for the latency charts instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tRErsduVux6kTi7r1Cqce

---
_Generated by [Claude Code](https://claude.ai/code/session_016tRErsduVux6kTi7r1Cqce)_