### PR TITLE
golf: room chat panel over the v2 wire (MoonBase#1226 task 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,82 @@
 # MuchQ
 
-Just some doodles and a pretty chill game.
+Just some doodles and a few pretty chill games. Lives at [muchq.com](https://muchq.com).
 
 ## 🚀 Quick Start
-
-### Development
 
 ```bash
 # Install dependencies
 npm install
 
-# Start development server
+# Start the dev server (http://localhost:3000)
 npm run dev
 
-# Open http://localhost:3000
+# Point game/API traffic at a local backend on :2015 instead of prod
+npm run local-server
 ```
 
-### Building
+## ✅ Checks
 
 ```bash
 # Type check
 npm run typecheck
 
-# Lint code
+# Lint (zero-warning budget)
 npm run lint
 
-# Run tests
+# Tests: watch mode, one-shot, or with the vitest UI
 npm run test
+npm run test:run
+npm run test:ui
 
-# Build for production
+# Production build / preview
 npm run build
-
-# Preview production build
 npm run preview
+
+# Deploy (Cloudflare Workers via wrangler)
+npm run deploy
 ```
+
+## 🕹️ What's Here
+
+| Route | App |
+|---|---|
+| `/golf` | Multiplayer 4-card golf — rooms, permalinks, and (on the v2 wire) room chat |
+| `/thoughts` | 3D multiplayer thoughts game |
+| `/party` | Rescue Party |
+| `/quest` | Quest — score-chasing arcade game |
+| `/tracy` | Ray tracer portraits |
+| `/posterize` | Image posterizer |
+| `/wordchains` | Word chain puzzles |
+| `/metrics` | Live service/host dashboards for the backend fleet |
+| `/resilience` | Distributed-systems game |
+| `/groups`, `/sets`, `/top` | Math learning modules (permutation groups, sets, Topology Quest) |
+
+### Golf v1/v2
+
+Golf speaks two wires. The default v1 protocol is documented in [GOLF.md](GOLF.md); the v2
+event-stream hub is a per-browser beta — opt in with `?golf=v2` (sticky via localStorage),
+back out with `?golf=v1`, or default a build in with `VITE_GOLF_V2_DEFAULT=true`. Room chat
+is v2-only, and the UI reveals it only once the server actually delivers chat on the wire.
 
 ## 🏗️ Project Structure
 
 ```
 src/
-├── components/          # React components
-│   ├── Navigation.tsx   # Main navigation
-│   ├── JuliaSetBackground.tsx # WebGL Julia set renderer
-│   ├── MathAnimations.tsx     # Floating math equations
-│   ├── ThoughtsGame.tsx       # 3D thoughts game
-│   ├── ThoughtsNavigation.tsx # Thoughts page navigation
-│   ├── GolfGame.tsx     # Golf game component
-│   ├── GolfNavigation.tsx     # Golf page navigation
-│   ├── GroupsNavigation.tsx   # Groups page navigation
-│   ├── PermutationVisualizer.tsx # Interactive permutation tool
-│   ├── CycleDecomposer.tsx    # Cycle decomposition calculator
-│   ├── PermutationQuiz.tsx    # Interactive quiz component
-│   ├── SignCalculator.tsx     # Permutation sign calculator
-│   └── __tests__/       # Component tests
-├── hooks/               # Custom React hooks
-│   ├── useWebGL.ts      # WebGL Julia set logic
-│   ├── useThoughtsGame.ts # Thoughts game engine logic
-│   └── useGolfGame.ts   # Golf game engine logic
-├── pages/               # Page components
-│   ├── HomePage.tsx     # Landing page
-│   ├── ThoughtsPage.tsx # Thoughts game page
-│   ├── GolfPage.tsx     # Golf game page
-│   └── GroupsPage.tsx   # Permutation groups learning module
-├── types/               # TypeScript type definitions
-│   ├── game.ts          # Game-related types
-│   └── vite-env.d.ts    # Vite environment types
-├── utils/               # Utility functions
-│   └── gameUtils.ts     # Game helper functions
-└── test/                # Test configuration
-    └── setup.ts         # Test setup
+├── apps/       # One directory per app (golf, thoughts, metrics-systems, …):
+│               # components, styles, and tests live with their app
+├── core/       # Page shells and routing targets
+├── shared/     # Components shared across apps (navigation, backgrounds, …)
+├── hooks/      # Cross-app React hooks (useGolfGame, useThoughtsGame, …)
+├── plugins/    # Network plugins for the multiplayer games
+├── types/      # Shared TypeScript contracts (adapter interfaces, wire shapes)
+├── utils/      # Adapters, permalinks, feature flags, helpers
+└── test/       # Vitest setup
 ```
 
-## 🧪 Testing
+Routes are declared in `src/App.tsx`.
 
-```bash
-# Run tests in watch mode
-npm run test
+## 📄 Documentation
 
-# Run tests with UI
-npm run test:ui
-
-# Run tests once
-npm run test -- --run
-```
-
-## 📝 Original Migration
-
-Old time-y implementation is preserved in the `backup/` directory.
-
-## Documentation
-
-- [Thoughts Multiplayer API](THOUGHTS.md) - WebSocket API specification for the multiplayer game environment
+- [GOLF.md](GOLF.md) — Golf multiplayer WebSocket API (v1)
+- [THOUGHTS.md](THOUGHTS.md) — Thoughts multiplayer WebSocket API

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import styles from './GolfGame.module.css'
 import { useGolfGame } from '@/hooks/useGolfGame'
 import PermalinkDisplay from './PermalinkDisplay'
+import RoomChat from './RoomChat'
 import NewGameNotification from './NewGameNotification'
 import type { ParsedPermalinkParams } from '../../../utils/golfPermalinks'
 import { isGolfV2Enabled, setGolfV2Enabled } from '../../../utils/golfV2'
@@ -80,7 +81,13 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     leaveRoom,
     dismissNewGameNotification,
     joinNewGame,
-    permalinkJoinAttempt
+    permalinkJoinAttempt,
+    chatMessages,
+    chatUnreadCount,
+    chatAvailable,
+    sendChat,
+    markChatSeen,
+    isConnected
   } = useGolfGame({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConnectionChange, permalinkParams })
 
   const isGameWinner = (player: Player | null | undefined) => {
@@ -381,6 +388,17 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
           </button>
         </div>
 
+        {chatAvailable && (
+          <RoomChat
+            messages={chatMessages}
+            playerId={playerId}
+            unreadCount={chatUnreadCount}
+            connected={isConnected}
+            onSend={sendChat}
+            onSeen={markChatSeen}
+          />
+        )}
+
         {notification && (
           <div className={styles.notification}>
             {notification}
@@ -671,6 +689,17 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
           <div className={styles.countdownNumber}>{peekCountdown}</div>
           <div className={styles.countdownText}>All players have peeked!</div>
         </div>
+      )}
+
+      {chatAvailable && (
+        <RoomChat
+          messages={chatMessages}
+          playerId={playerId}
+          unreadCount={chatUnreadCount}
+          connected={isConnected}
+          onSend={sendChat}
+          onSeen={markChatSeen}
+        />
       )}
     </div>
   )

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -85,6 +85,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     chatMessages,
     chatUnreadCount,
     chatAvailable,
+    chatReplayUpTo,
     sendChat,
     markChatSeen,
     isConnected
@@ -394,6 +395,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
             playerId={playerId}
             unreadCount={chatUnreadCount}
             connected={isConnected}
+            replayUpTo={chatReplayUpTo}
             onSend={sendChat}
             onSeen={markChatSeen}
           />
@@ -697,6 +699,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
           playerId={playerId}
           unreadCount={chatUnreadCount}
           connected={isConnected}
+          replayUpTo={chatReplayUpTo}
           onSend={sendChat}
           onSeen={markChatSeen}
         />

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -83,11 +83,9 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     joinNewGame,
     permalinkJoinAttempt,
     chatMessages,
-    chatUnreadCount,
     chatAvailable,
     chatReplayUpTo,
     sendChat,
-    markChatSeen,
     isConnected
   } = useGolfGame({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConnectionChange, permalinkParams })
 
@@ -147,6 +145,21 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
       </div>
     )
   }
+
+  // One element, rendered at the same tree position (first child of the
+  // returned fragment) by both in-room branches, so a lobby↔game
+  // transition keeps the panel instance — composer draft, drawer state,
+  // scroll — instead of remounting it. The panel is position:fixed, so
+  // its place in document flow doesn't matter.
+  const roomChat = chatAvailable ? (
+    <RoomChat
+      messages={chatMessages}
+      playerId={playerId}
+      connected={isConnected}
+      replayUpTo={chatReplayUpTo}
+      onSend={sendChat}
+    />
+  ) : null
 
   if (isInLobby) {
     return (
@@ -270,6 +283,8 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
   // Room lobby state - user is in room but not in a specific game
   if (isInRoom && !gameState && roomState) {
     return (
+      <>
+      {roomChat}
       <div className={styles.roomLobby}>
         <div className={styles.roomHeader}>
           <div className={styles.roomHeaderTop}>
@@ -389,24 +404,13 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
           </button>
         </div>
 
-        {chatAvailable && (
-          <RoomChat
-            messages={chatMessages}
-            playerId={playerId}
-            unreadCount={chatUnreadCount}
-            connected={isConnected}
-            replayUpTo={chatReplayUpTo}
-            onSend={sendChat}
-            onSeen={markChatSeen}
-          />
-        )}
-
         {notification && (
           <div className={styles.notification}>
             {notification}
           </div>
         )}
       </div>
+      </>
     )
   }
 
@@ -430,6 +434,8 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
   }
 
   return (
+    <>
+    {roomChat}
     <div className={styles.gameContainer}>
       <div className={styles.gameHeader}>
         <div className={styles.gameHeaderTop}>
@@ -693,18 +699,8 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
         </div>
       )}
 
-      {chatAvailable && (
-        <RoomChat
-          messages={chatMessages}
-          playerId={playerId}
-          unreadCount={chatUnreadCount}
-          connected={isConnected}
-          replayUpTo={chatReplayUpTo}
-          onSend={sendChat}
-          onSeen={markChatSeen}
-        />
-      )}
     </div>
+    </>
   )
 }
 

--- a/src/apps/golf/components/RoomChat.module.css
+++ b/src/apps/golf/components/RoomChat.module.css
@@ -1,0 +1,287 @@
+/* Room chat (MoonBase#1226), in the golf green/glass language. Drawer
+ * mode is the default — a floating toggle opening a bottom sheet, so
+ * nothing chat-shaped can cover cards or turn controls while closed —
+ * and viewports wide enough to have margin beside the 1200px content
+ * column dock the panel there as a stable sidebar instead. */
+
+.chatRoot {
+  display: contents;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.title {
+  font-weight: 600;
+  color: #fff;
+}
+
+.connection {
+  flex: 1;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  text-align: right;
+}
+
+.closeButton {
+  display: none;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.messageList {
+  flex: 1;
+  min-height: 8rem;
+  max-height: 24rem;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.emptyState {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.875rem;
+  text-align: center;
+  margin: auto 0;
+}
+
+.message {
+  max-width: 90%;
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.5rem;
+  padding: 0.375rem 0.625rem;
+}
+
+.ownMessage {
+  align-self: flex-end;
+  background: rgba(144, 238, 144, 0.15);
+  border-color: rgba(144, 238, 144, 0.3);
+}
+
+.messageMeta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  margin-bottom: 0.125rem;
+}
+
+.sender {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #90ee90;
+}
+
+.timestamp {
+  font-size: 0.6875rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.messageText {
+  color: #fff;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.newMessages {
+  margin: 0 auto 0.25rem;
+  background: rgba(144, 238, 144, 0.2);
+  border: 1px solid rgba(144, 238, 144, 0.4);
+  border-radius: 1rem;
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+}
+
+.composer {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  align-items: flex-end;
+}
+
+.input {
+  flex: 1;
+  resize: none;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 0.5rem;
+  color: #fff;
+  font: inherit;
+  font-size: 0.875rem;
+  padding: 0.5rem;
+}
+
+.input:disabled {
+  opacity: 0.5;
+}
+
+.composerSide {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.byteCount {
+  font-size: 0.6875rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.overLimit {
+  color: #ff8080;
+  font-weight: 600;
+}
+
+.sendButton {
+  background: #90ee90;
+  border: none;
+  border-radius: 0.5rem;
+  color: #0a3d0a;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.sendButton:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.drawerToggle {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 40;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(20, 60, 20, 0.9);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.unreadBadge {
+  position: absolute;
+  top: -0.375rem;
+  right: -0.375rem;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.625rem;
+  background: #ff6666;
+  color: #fff;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.25rem;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Drawer mode is the default: the golf content is centered at
+ * max-width 1200px, so only genuinely wide viewports have margin a
+ * docked panel can occupy without covering cards or controls. */
+.drawerToggle {
+  display: block;
+}
+
+.panel {
+  display: none;
+}
+
+.drawerOpen .panel {
+  display: flex;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 30%;
+  z-index: 50;
+  border-radius: 1rem 1rem 0 0;
+  background: rgba(10, 40, 10, 0.97);
+}
+
+.drawerOpen .drawerToggle {
+  display: none;
+}
+
+.drawerOpen .closeButton {
+  display: block;
+}
+
+.drawerOpen .messageList {
+  max-height: none;
+}
+
+@media (min-width: 1560px) {
+  /* Enough viewport margin beside the 1200px content column: dock the
+   * panel there permanently and retire the drawer chrome. */
+  .drawerToggle,
+  .drawerOpen .drawerToggle {
+    display: none;
+  }
+
+  .panel,
+  .drawerOpen .panel {
+    display: flex;
+    position: fixed;
+    right: 1rem;
+    top: 6rem;
+    bottom: 1.5rem;
+    left: auto;
+    width: 20rem;
+    z-index: 30;
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .closeButton,
+  .drawerOpen .closeButton {
+    display: none;
+  }
+
+  .messageList,
+  .drawerOpen .messageList {
+    max-height: none;
+  }
+}

--- a/src/apps/golf/components/RoomChat.module.css
+++ b/src/apps/golf/components/RoomChat.module.css
@@ -55,6 +55,9 @@
   min-height: 8rem;
   max-height: 24rem;
   overflow-y: auto;
+  /* Reaching the top of scrollback must not start scrolling the game
+   * behind the sheet. */
+  overscroll-behavior: contain;
   padding: 0.75rem 1rem;
   display: flex;
   flex-direction: column;
@@ -220,13 +223,24 @@
 
 /* Drawer mode is the default: the golf content is centered at
  * max-width 1200px, so only genuinely wide viewports have margin a
- * docked panel can occupy without covering cards or controls. */
+ * docked panel can occupy without covering cards or controls. There is
+ * no media query here — RoomChat.tsx owns the breakpoint (DOCKED_QUERY)
+ * and stamps .docked, so styling and behavior can't disagree. */
 .drawerToggle {
   display: block;
+  /* Clear the iOS home indicator. */
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
 }
 
 .panel {
   display: none;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 45;
+  background: rgba(0, 0, 0, 0.4);
 }
 
 .drawerOpen .panel {
@@ -235,10 +249,17 @@
   left: 0;
   right: 0;
   bottom: 0;
-  top: 30%;
+  /* dvh tracks the visual viewport, so the composer stays reachable
+   * when the mobile keyboard or browser chrome resizes the screen. */
+  height: 70vh;
+  height: 70dvh;
   z-index: 50;
   border-radius: 1rem 1rem 0 0;
   background: rgba(10, 40, 10, 0.97);
+}
+
+.drawerOpen .composer {
+  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
 }
 
 .drawerOpen .drawerToggle {
@@ -253,37 +274,63 @@
   max-height: none;
 }
 
-@media (min-width: 1880px) {
-  /* Enough viewport margin beside the 1200px content column to hold the
-   * 21rem panel footprint on both sides (1200 + 2 × 336 = 1872): dock
-   * the panel there permanently and retire the drawer chrome. Keep in
-   * sync with DOCKED_QUERY in RoomChat.tsx. */
-  .drawerToggle,
-  .drawerOpen .drawerToggle {
-    display: none;
+@media (prefers-reduced-motion: no-preference) {
+  .drawerOpen:not(.docked) .panel {
+    animation: chatSlideUp 0.25s ease;
   }
 
-  .panel,
-  .drawerOpen .panel {
-    display: flex;
-    position: fixed;
-    right: 1rem;
-    top: 6rem;
-    bottom: 1.5rem;
-    left: auto;
-    width: 20rem;
-    z-index: 30;
-    border-radius: 1rem;
-    background: rgba(255, 255, 255, 0.1);
+  .backdrop {
+    animation: chatFadeIn 0.2s ease;
   }
+}
 
-  .closeButton,
-  .drawerOpen .closeButton {
-    display: none;
+@keyframes chatSlideUp {
+  from {
+    transform: translateY(100%);
   }
+  to {
+    transform: translateY(0);
+  }
+}
 
-  .messageList,
-  .drawerOpen .messageList {
-    max-height: none;
+@keyframes chatFadeIn {
+  from {
+    opacity: 0;
   }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Docked mode, stamped by RoomChat.tsx once the viewport has margin for
+ * the 21rem panel footprint beside the 1200px content column on both
+ * sides (1200 + 2 × 336 = 1872). Last so it wins over the drawer rules
+ * whatever the drawer state is. */
+.docked .panel {
+  display: flex;
+  position: fixed;
+  left: auto;
+  right: 1rem;
+  top: 6rem;
+  bottom: 1.5rem;
+  height: auto;
+  width: 20rem;
+  z-index: 30;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  animation: none;
+}
+
+.docked .drawerToggle,
+.docked .closeButton,
+.docked .backdrop {
+  display: none;
+}
+
+.docked .composer {
+  padding-bottom: 0.75rem;
+}
+
+.docked .messageList {
+  max-height: none;
 }

--- a/src/apps/golf/components/RoomChat.module.css
+++ b/src/apps/golf/components/RoomChat.module.css
@@ -253,9 +253,11 @@
   max-height: none;
 }
 
-@media (min-width: 1560px) {
-  /* Enough viewport margin beside the 1200px content column: dock the
-   * panel there permanently and retire the drawer chrome. */
+@media (min-width: 1880px) {
+  /* Enough viewport margin beside the 1200px content column to hold the
+   * 21rem panel footprint on both sides (1200 + 2 × 336 = 1872): dock
+   * the panel there permanently and retire the drawer chrome. Keep in
+   * sync with DOCKED_QUERY in RoomChat.tsx. */
   .drawerToggle,
   .drawerOpen .drawerToggle {
     display: none;

--- a/src/apps/golf/components/RoomChat.tsx
+++ b/src/apps/golf/components/RoomChat.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import styles from './RoomChat.module.css'
+import type { ChatMessage } from '@/types/golfChat'
+import { CHAT_TEXT_BYTE_LIMIT, chatTextBytes } from '@/types/golfChat'
+
+// Room chat (MoonBase#1226): one component for both the room lobby and
+// in-game views. Desktop renders it as a stable side panel; narrow
+// screens collapse it to a floating button with an unread badge that
+// opens a bottom sheet (the CSS module owns which of the two shows).
+//
+// Text renders exclusively as React text nodes — no
+// dangerouslySetInnerHTML, no linkification, no markdown — so a message
+// that looks like HTML stays a string on every screen it reaches.
+
+interface RoomChatProps {
+  messages: ChatMessage[]
+  playerId: string
+  unreadCount: number
+  connected: boolean
+  onSend: (text: string) => void
+  onSeen: () => void
+}
+
+// How close to the bottom (px) still counts as "following": auto-scroll
+// only chases new messages for readers already at the end, so scrollback
+// is never yanked away.
+const FOLLOW_THRESHOLD_PX = 48
+
+const formatTime = (unixMillis: number) =>
+  new Date(unixMillis).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }: RoomChatProps) => {
+  const [draft, setDraft] = useState('')
+  // Mobile-only: whether the drawer is open. The desktop panel ignores
+  // it — CSS keeps the panel visible regardless.
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const followingRef = useRef(true)
+  // Ids at or below this had already rendered when the component (or its
+  // history) first painted; only messages after it are announced to
+  // screen readers — a 100-message replay must not be read aloud.
+  const announceAfterIdRef = useRef<number | null>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  const latestId = messages.length > 0 ? messages[messages.length - 1].messageId : 0
+
+  const handleScroll = useCallback(() => {
+    const list = listRef.current
+    if (!list) return
+    const fromBottom = list.scrollHeight - list.scrollTop - list.clientHeight
+    followingRef.current = fromBottom <= FOLLOW_THRESHOLD_PX
+    if (followingRef.current) onSeen()
+  }, [onSeen])
+
+  // First paint (and the history that arrives with it) sets the
+  // announcement watermark without announcing anything.
+  useEffect(() => {
+    if (announceAfterIdRef.current === null && messages.length >= 0) {
+      announceAfterIdRef.current = latestId
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    const list = listRef.current
+    if (list && followingRef.current) {
+      list.scrollTop = list.scrollHeight
+      onSeen()
+    }
+    const watermark = announceAfterIdRef.current
+    if (watermark !== null && latestId > watermark) {
+      const fresh = messages.filter(m => m.messageId > watermark)
+      const last = fresh[fresh.length - 1]
+      if (last) setAnnouncement(`${last.playerId}: ${last.text}`)
+      announceAfterIdRef.current = latestId
+    }
+  }, [latestId, messages, onSeen])
+
+  const send = useCallback(() => {
+    const trimmed = draft.trim()
+    if (!trimmed || !connected) return
+    if (chatTextBytes(trimmed) > CHAT_TEXT_BYTE_LIMIT) return
+    onSend(trimmed)
+    setDraft('')
+    followingRef.current = true
+  }, [draft, connected, onSend])
+
+  const onComposerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault()
+        send()
+      }
+    },
+    [send]
+  )
+
+  const draftBytes = chatTextBytes(draft.trim())
+  const overLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT
+  const nearLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT - 100
+
+  const openDrawer = useCallback(() => {
+    setDrawerOpen(true)
+    onSeen()
+  }, [onSeen])
+
+  const panel = (
+    <div className={styles.panel} data-testid="room-chat-panel">
+      <div className={styles.header}>
+        <span className={styles.title}>Room chat</span>
+        <span className={styles.connection}>
+          {connected ? '' : 'reconnecting…'}
+        </span>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={() => setDrawerOpen(false)}
+          aria-label="Close chat"
+        >
+          ×
+        </button>
+      </div>
+      <div className={styles.messageList} ref={listRef} onScroll={handleScroll} data-testid="chat-messages">
+        {messages.length === 0 ? (
+          <div className={styles.emptyState}>No messages yet — say hello.</div>
+        ) : (
+          messages.map(message => (
+            <div
+              key={message.messageId}
+              className={`${styles.message} ${message.playerId === playerId ? styles.ownMessage : ''}`}
+            >
+              <div className={styles.messageMeta}>
+                <span className={styles.sender}>{message.playerId}</span>
+                <span className={styles.timestamp}>{formatTime(message.sentAtUnixMillis)}</span>
+              </div>
+              <div className={styles.messageText}>{message.text}</div>
+            </div>
+          ))
+        )}
+      </div>
+      {unreadCount > 0 && (
+        <button
+          type="button"
+          className={styles.newMessages}
+          onClick={() => {
+            const list = listRef.current
+            if (list) list.scrollTop = list.scrollHeight
+            followingRef.current = true
+            onSeen()
+          }}
+        >
+          {unreadCount} new message{unreadCount === 1 ? '' : 's'}
+        </button>
+      )}
+      <div className={styles.composer}>
+        <textarea
+          className={styles.input}
+          value={draft}
+          onChange={event => setDraft(event.target.value)}
+          onKeyDown={onComposerKeyDown}
+          placeholder={connected ? 'Message the room' : 'Reconnecting…'}
+          disabled={!connected}
+          rows={2}
+          aria-label="Chat message"
+        />
+        <div className={styles.composerSide}>
+          {(nearLimit || overLimit) && (
+            <span className={`${styles.byteCount} ${overLimit ? styles.overLimit : ''}`}>
+              {draftBytes}/{CHAT_TEXT_BYTE_LIMIT}
+            </span>
+          )}
+          <button
+            type="button"
+            className={styles.sendButton}
+            onClick={send}
+            disabled={!connected || draft.trim().length === 0 || overLimit}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+      {/* Live messages only: the history replay never lands here. */}
+      <div className={styles.srOnly} aria-live="polite">
+        {announcement}
+      </div>
+    </div>
+  )
+
+  return (
+    <div className={`${styles.chatRoot} ${drawerOpen ? styles.drawerOpen : ''}`}>
+      {panel}
+      <button
+        type="button"
+        className={styles.drawerToggle}
+        onClick={openDrawer}
+        aria-label={unreadCount > 0 ? `Open chat, ${unreadCount} unread` : 'Open chat'}
+      >
+        💬
+        {unreadCount > 0 && <span className={styles.unreadBadge}>{unreadCount}</span>}
+      </button>
+    </div>
+  )
+}
+
+export default RoomChat

--- a/src/apps/golf/components/RoomChat.tsx
+++ b/src/apps/golf/components/RoomChat.tsx
@@ -1,13 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styles from './RoomChat.module.css'
 import type { ChatMessage } from '@/types/golfChat'
 import { CHAT_TEXT_BYTE_LIMIT, chatTextBytes } from '@/types/golfChat'
 
-// Room chat (MoonBase#1226): one component for both the room lobby and
-// in-game views. Wide viewports render it as a stable side panel; narrow
-// screens collapse it to a floating button with an unread badge that
-// opens a bottom sheet (the CSS module owns which of the two shows, and
-// DOCKED_QUERY mirrors that decision for the logic that needs it).
+// Room chat (MoonBase#1226): one stable instance for both the room
+// lobby and in-game views. Wide viewports dock it as a side panel;
+// narrow screens collapse it to a floating button with an unread badge
+// that opens a bottom sheet. The component owns which mode is live
+// (DOCKED_QUERY) and stamps the class the CSS module styles against,
+// so presentation and the scroll/seen/focus logic can never disagree.
+//
+// Seen/unread is presentation state and lives here: only this component
+// knows whether the panel is visible and where the reader is scrolled.
 //
 // Text renders exclusively as React text nodes — no
 // dangerouslySetInnerHTML, no linkification, no markdown — so a message
@@ -16,14 +20,13 @@ import { CHAT_TEXT_BYTE_LIMIT, chatTextBytes } from '@/types/golfChat'
 interface RoomChatProps {
   messages: ChatMessage[]
   playerId: string
-  unreadCount: number
   connected: boolean
-  // Highest messageId ever delivered by a history replay. Replayed
-  // messages are never announced to screen readers — only ids above
-  // both this and the mount watermark are genuinely live.
+  // Highest messageId ever delivered by a history replay (wire-derived,
+  // so the hook owns it). Replayed messages are never announced to
+  // screen readers — only ids above both this and the mount watermark
+  // are genuinely live.
   replayUpTo: number
   onSend: (text: string) => void
-  onSeen: () => void
 }
 
 // How close to the bottom (px) still counts as "following": auto-scroll
@@ -31,35 +34,53 @@ interface RoomChatProps {
 // is never yanked away.
 const FOLLOW_THRESHOLD_PX = 48
 
-// Paired with the @media block in RoomChat.module.css: the panel docks
-// only once the viewport leaves real margin beside the 1200px content
-// column (1200 + 2 × (1rem gap + 20rem panel) = 1872, rounded up).
+// The panel docks only once the viewport leaves real margin beside the
+// 1200px content column (1200 + 2 × (1rem gap + 20rem panel) = 1872,
+// rounded up). The CSS module has no media query — it styles the
+// .docked class this component stamps from this one query.
 const DOCKED_QUERY = '(min-width: 1880px)'
 
-const formatTime = (unixMillis: number) =>
-  new Date(unixMillis).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+const timeFormat = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
 
-const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSend, onSeen }: RoomChatProps) => {
+const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomChatProps) => {
   const [draft, setDraft] = useState('')
   // Drawer-mode only: whether the bottom sheet is open. The docked
-  // panel ignores it — CSS keeps the panel visible regardless.
+  // panel ignores it — the .docked rules keep the panel visible.
   const [drawerOpen, setDrawerOpen] = useState(false)
-  // Mirrors the CSS breakpoint so scroll/seen/focus logic knows whether
-  // the panel is actually on screen. Environments without matchMedia
-  // (jsdom) are treated as drawer mode.
-  const [docked, setDocked] = useState(false)
+  // Environments without matchMedia (jsdom) are drawer mode.
+  const [docked, setDocked] = useState(
+    () => typeof window.matchMedia === 'function' && window.matchMedia(DOCKED_QUERY).matches
+  )
+  const [lastSeenId, setLastSeenId] = useState(0)
   const listRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const toggleRef = useRef<HTMLButtonElement | null>(null)
   const wasDrawerOpenRef = useRef(false)
   const followingRef = useRef(true)
-  // Ids at or below this had already rendered when the component first
-  // painted; only messages above it (and above replayUpTo) are announced
-  // to screen readers — a 100-message replay must not be read aloud.
-  const announceAfterIdRef = useRef<number | null>(null)
-  const [announcement, setAnnouncement] = useState<{ id: number; text: string } | null>(null)
 
   const latestId = messages.length > 0 ? messages[messages.length - 1].messageId : 0
+
+  // Screen-reader announcements, derived in render (React's "adjusting
+  // state when a prop changes" pattern). Ids at or below `upTo` had
+  // already rendered when the previous render committed; only a tail
+  // above both it and replayUpTo is a genuinely live arrival — a
+  // 100-message replay must never be read aloud. The initializer covers
+  // mounting onto existing messages, and a smaller latestId means the
+  // room's chat state was reset.
+  const [announced, setAnnounced] = useState<{
+    upTo: number
+    entry: { id: number; text: string } | null
+  }>({ upTo: latestId, entry: null })
+  if (latestId !== announced.upTo) {
+    const last = messages[messages.length - 1]
+    const entry =
+      latestId > announced.upTo && last && last.messageId > replayUpTo
+        ? { id: last.messageId, text: `${last.playerId}: ${last.text}` }
+        : latestId < announced.upTo
+          ? null
+          : announced.entry
+    setAnnounced({ upTo: latestId, entry })
+  }
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return
@@ -72,13 +93,27 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSe
 
   const panelVisible = docked || drawerOpen
 
+  const markSeen = useCallback(() => {
+    setLastSeenId(latestId)
+  }, [latestId])
+
+  // lastSeenId can never legitimately exceed latestId (markSeen assigns
+  // it), so a smaller latestId means the room's chat state was reset —
+  // everything is unseen again, derived rather than synchronized.
+  const effectiveLastSeenId = lastSeenId > latestId ? 0 : lastSeenId
+
+  const unreadCount = useMemo(
+    () => messages.reduce((count, m) => (m.messageId > effectiveLastSeenId ? count + 1 : count), 0),
+    [messages, effectiveLastSeenId]
+  )
+
   const handleScroll = useCallback(() => {
     const list = listRef.current
     if (!list) return
     const fromBottom = list.scrollHeight - list.scrollTop - list.clientHeight
     followingRef.current = fromBottom <= FOLLOW_THRESHOLD_PX
-    if (followingRef.current) onSeen()
-  }, [onSeen])
+    if (followingRef.current) markSeen()
+  }, [markSeen])
 
   // Follow the newest message — but only while the panel is actually on
   // screen. A hidden panel has no reader: marking arrivals seen there
@@ -90,37 +125,21 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSe
     const list = listRef.current
     if (panelVisible && list && followingRef.current) {
       list.scrollTop = list.scrollHeight
-      onSeen()
+      markSeen()
     }
-  }, [latestId, panelVisible, onSeen])
+  }, [latestId, panelVisible, markSeen])
 
-  // Announcements are independent of panel visibility — the live region
-  // sits outside the panel, so closed-drawer arrivals still reach
-  // screen readers.
-  useEffect(() => {
-    const watermark = announceAfterIdRef.current
-    if (watermark === null || latestId < watermark) {
-      // First paint, or the room's chat state was reset: move the
-      // watermark silently.
-      announceAfterIdRef.current = latestId
-      return
-    }
-    if (latestId > watermark) {
-      const fresh = messages.filter(m => m.messageId > watermark && m.messageId > replayUpTo)
-      const last = fresh[fresh.length - 1]
-      if (last) setAnnouncement({ id: last.messageId, text: `${last.playerId}: ${last.text}` })
-      announceAfterIdRef.current = latestId
-    }
-  }, [latestId, messages, replayUpTo])
+  const trimmedDraft = draft.trim()
+  const draftBytes = chatTextBytes(trimmedDraft)
+  const overLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT
+  const nearLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT - 100
 
   const send = useCallback(() => {
-    const trimmed = draft.trim()
-    if (!trimmed || !connected) return
-    if (chatTextBytes(trimmed) > CHAT_TEXT_BYTE_LIMIT) return
-    onSend(trimmed)
+    if (!trimmedDraft || !connected || overLimit) return
+    onSend(trimmedDraft)
     setDraft('')
     followingRef.current = true
-  }, [draft, connected, onSend])
+  }, [trimmedDraft, connected, overLimit, onSend])
 
   const onComposerKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -132,14 +151,10 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSe
     [send]
   )
 
-  const draftBytes = chatTextBytes(draft.trim())
-  const overLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT
-  const nearLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT - 100
-
   const openDrawer = useCallback(() => {
     setDrawerOpen(true)
-    onSeen()
-  }, [onSeen])
+    markSeen()
+  }, [markSeen])
 
   const closeDrawer = useCallback(() => {
     setDrawerOpen(false)
@@ -163,94 +178,108 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSe
     [docked, drawerOpen, closeDrawer]
   )
 
-  const panel = (
-    <div
-      className={styles.panel}
-      data-testid="room-chat-panel"
-      role={!docked && drawerOpen ? 'dialog' : undefined}
-      aria-label="Room chat"
-      onKeyDown={onPanelKeyDown}
-    >
-      <div className={styles.header}>
-        <span className={styles.title}>Room chat</span>
-        <span className={styles.connection}>
-          {connected ? '' : 'reconnecting…'}
-        </span>
-        <button
-          type="button"
-          className={styles.closeButton}
-          onClick={closeDrawer}
-          aria-label="Close chat"
+  // Message rows depend only on messages and whose they are — not on
+  // the draft, so typing doesn't rebuild up to 100 rows per keystroke.
+  const messageItems = useMemo(
+    () =>
+      messages.map(message => (
+        <div
+          key={message.messageId}
+          className={`${styles.message} ${message.playerId === playerId ? styles.ownMessage : ''}`}
         >
-          ×
-        </button>
-      </div>
-      <div className={styles.messageList} ref={listRef} onScroll={handleScroll} data-testid="chat-messages">
-        {messages.length === 0 ? (
-          <div className={styles.emptyState}>No messages yet — say hello.</div>
-        ) : (
-          messages.map(message => (
-            <div
-              key={message.messageId}
-              className={`${styles.message} ${message.playerId === playerId ? styles.ownMessage : ''}`}
-            >
-              <div className={styles.messageMeta}>
-                <span className={styles.sender}>{message.playerId}</span>
-                <span className={styles.timestamp}>{formatTime(message.sentAtUnixMillis)}</span>
-              </div>
-              <div className={styles.messageText}>{message.text}</div>
-            </div>
-          ))
-        )}
-      </div>
-      {unreadCount > 0 && (
-        <button
-          type="button"
-          className={styles.newMessages}
-          onClick={() => {
-            const list = listRef.current
-            if (list) list.scrollTop = list.scrollHeight
-            followingRef.current = true
-            onSeen()
-          }}
-        >
-          {unreadCount} new message{unreadCount === 1 ? '' : 's'}
-        </button>
-      )}
-      <div className={styles.composer}>
-        <textarea
-          ref={inputRef}
-          className={styles.input}
-          value={draft}
-          onChange={event => setDraft(event.target.value)}
-          onKeyDown={onComposerKeyDown}
-          placeholder={connected ? 'Message the room' : 'Reconnecting…'}
-          disabled={!connected}
-          rows={2}
-          aria-label="Chat message"
-        />
-        <div className={styles.composerSide}>
-          {(nearLimit || overLimit) && (
-            <span className={`${styles.byteCount} ${overLimit ? styles.overLimit : ''}`}>
-              {draftBytes}/{CHAT_TEXT_BYTE_LIMIT}
-            </span>
-          )}
-          <button
-            type="button"
-            className={styles.sendButton}
-            onClick={send}
-            disabled={!connected || draft.trim().length === 0 || overLimit}
-          >
-            Send
-          </button>
+          <div className={styles.messageMeta}>
+            <span className={styles.sender}>{message.playerId}</span>
+            <span className={styles.timestamp}>{timeFormat.format(message.sentAtUnixMillis)}</span>
+          </div>
+          <div className={styles.messageText}>{message.text}</div>
         </div>
-      </div>
-    </div>
+      )),
+    [messages, playerId]
   )
 
+  const rootClass = [
+    styles.chatRoot,
+    drawerOpen ? styles.drawerOpen : '',
+    docked ? styles.docked : ''
+  ].join(' ')
+
   return (
-    <div className={`${styles.chatRoot} ${drawerOpen ? styles.drawerOpen : ''}`}>
-      {panel}
+    <div className={rootClass}>
+      {drawerOpen && !docked && (
+        // Pointer-only affordance: keyboard and screen-reader users
+        // close via Escape or the labeled close button.
+        <div className={styles.backdrop} onClick={closeDrawer} aria-hidden="true" />
+      )}
+      <div
+        className={styles.panel}
+        role={!docked && drawerOpen ? 'dialog' : undefined}
+        aria-label="Room chat"
+        onKeyDown={onPanelKeyDown}
+      >
+        <div className={styles.header}>
+          <span className={styles.title}>Room chat</span>
+          <span className={styles.connection}>
+            {connected ? '' : 'reconnecting…'}
+          </span>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={closeDrawer}
+            aria-label="Close chat"
+          >
+            ×
+          </button>
+        </div>
+        <div className={styles.messageList} ref={listRef} onScroll={handleScroll} data-testid="chat-messages">
+          {messages.length === 0 ? (
+            <div className={styles.emptyState}>No messages yet — say hello.</div>
+          ) : (
+            messageItems
+          )}
+        </div>
+        {unreadCount > 0 && (
+          <button
+            type="button"
+            className={styles.newMessages}
+            onClick={() => {
+              const list = listRef.current
+              if (list) list.scrollTop = list.scrollHeight
+              followingRef.current = true
+              markSeen()
+            }}
+          >
+            {unreadCount} new message{unreadCount === 1 ? '' : 's'}
+          </button>
+        )}
+        <div className={styles.composer}>
+          <textarea
+            ref={inputRef}
+            className={styles.input}
+            value={draft}
+            onChange={event => setDraft(event.target.value)}
+            onKeyDown={onComposerKeyDown}
+            placeholder={connected ? 'Message the room' : 'Reconnecting…'}
+            disabled={!connected}
+            rows={2}
+            aria-label="Chat message"
+          />
+          <div className={styles.composerSide}>
+            {(nearLimit || overLimit) && (
+              <span className={`${styles.byteCount} ${overLimit ? styles.overLimit : ''}`}>
+                {draftBytes}/{CHAT_TEXT_BYTE_LIMIT}
+              </span>
+            )}
+            <button
+              type="button"
+              className={styles.sendButton}
+              onClick={send}
+              disabled={!connected || trimmedDraft.length === 0 || overLimit}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      </div>
       <button
         ref={toggleRef}
         type="button"
@@ -265,9 +294,9 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSe
         * panel so a closed drawer still announces; keyed by id so a
         * repeat of identical text is still a DOM mutation. */}
       <div className={styles.srOnly} aria-live="polite">
-        {announcement && (
-          <span key={announcement.id} data-message-id={announcement.id}>
-            {announcement.text}
+        {announced.entry && (
+          <span key={announced.entry.id} data-message-id={announced.entry.id}>
+            {announced.entry.text}
           </span>
         )}
       </div>

--- a/src/apps/golf/components/RoomChat.tsx
+++ b/src/apps/golf/components/RoomChat.tsx
@@ -4,9 +4,10 @@ import type { ChatMessage } from '@/types/golfChat'
 import { CHAT_TEXT_BYTE_LIMIT, chatTextBytes } from '@/types/golfChat'
 
 // Room chat (MoonBase#1226): one component for both the room lobby and
-// in-game views. Desktop renders it as a stable side panel; narrow
+// in-game views. Wide viewports render it as a stable side panel; narrow
 // screens collapse it to a floating button with an unread badge that
-// opens a bottom sheet (the CSS module owns which of the two shows).
+// opens a bottom sheet (the CSS module owns which of the two shows, and
+// DOCKED_QUERY mirrors that decision for the logic that needs it).
 //
 // Text renders exclusively as React text nodes — no
 // dangerouslySetInnerHTML, no linkification, no markdown — so a message
@@ -17,6 +18,10 @@ interface RoomChatProps {
   playerId: string
   unreadCount: number
   connected: boolean
+  // Highest messageId ever delivered by a history replay. Replayed
+  // messages are never announced to screen readers — only ids above
+  // both this and the mount watermark are genuinely live.
+  replayUpTo: number
   onSend: (text: string) => void
   onSeen: () => void
 }
@@ -26,23 +31,46 @@ interface RoomChatProps {
 // is never yanked away.
 const FOLLOW_THRESHOLD_PX = 48
 
+// Paired with the @media block in RoomChat.module.css: the panel docks
+// only once the viewport leaves real margin beside the 1200px content
+// column (1200 + 2 × (1rem gap + 20rem panel) = 1872, rounded up).
+const DOCKED_QUERY = '(min-width: 1880px)'
+
 const formatTime = (unixMillis: number) =>
   new Date(unixMillis).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
-const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }: RoomChatProps) => {
+const RoomChat = ({ messages, playerId, unreadCount, connected, replayUpTo, onSend, onSeen }: RoomChatProps) => {
   const [draft, setDraft] = useState('')
-  // Mobile-only: whether the drawer is open. The desktop panel ignores
-  // it — CSS keeps the panel visible regardless.
+  // Drawer-mode only: whether the bottom sheet is open. The docked
+  // panel ignores it — CSS keeps the panel visible regardless.
   const [drawerOpen, setDrawerOpen] = useState(false)
+  // Mirrors the CSS breakpoint so scroll/seen/focus logic knows whether
+  // the panel is actually on screen. Environments without matchMedia
+  // (jsdom) are treated as drawer mode.
+  const [docked, setDocked] = useState(false)
   const listRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLTextAreaElement | null>(null)
+  const toggleRef = useRef<HTMLButtonElement | null>(null)
+  const wasDrawerOpenRef = useRef(false)
   const followingRef = useRef(true)
-  // Ids at or below this had already rendered when the component (or its
-  // history) first painted; only messages after it are announced to
-  // screen readers — a 100-message replay must not be read aloud.
+  // Ids at or below this had already rendered when the component first
+  // painted; only messages above it (and above replayUpTo) are announced
+  // to screen readers — a 100-message replay must not be read aloud.
   const announceAfterIdRef = useRef<number | null>(null)
-  const [announcement, setAnnouncement] = useState('')
+  const [announcement, setAnnouncement] = useState<{ id: number; text: string } | null>(null)
 
   const latestId = messages.length > 0 ? messages[messages.length - 1].messageId : 0
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return
+    const mq = window.matchMedia(DOCKED_QUERY)
+    const update = () => setDocked(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  const panelVisible = docked || drawerOpen
 
   const handleScroll = useCallback(() => {
     const list = listRef.current
@@ -52,29 +80,38 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
     if (followingRef.current) onSeen()
   }, [onSeen])
 
-  // First paint (and the history that arrives with it) sets the
-  // announcement watermark without announcing anything.
-  useEffect(() => {
-    if (announceAfterIdRef.current === null && messages.length >= 0) {
-      announceAfterIdRef.current = latestId
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
+  // Follow the newest message — but only while the panel is actually on
+  // screen. A hidden panel has no reader: marking arrivals seen there
+  // would keep the unread badge permanently empty, and scrollTop writes
+  // against display:none are no-ops anyway. panelVisible in the deps
+  // also re-runs this when the drawer opens, so the sheet lands at the
+  // bottom instead of on the oldest message.
   useEffect(() => {
     const list = listRef.current
-    if (list && followingRef.current) {
+    if (panelVisible && list && followingRef.current) {
       list.scrollTop = list.scrollHeight
       onSeen()
     }
+  }, [latestId, panelVisible, onSeen])
+
+  // Announcements are independent of panel visibility — the live region
+  // sits outside the panel, so closed-drawer arrivals still reach
+  // screen readers.
+  useEffect(() => {
     const watermark = announceAfterIdRef.current
-    if (watermark !== null && latestId > watermark) {
-      const fresh = messages.filter(m => m.messageId > watermark)
+    if (watermark === null || latestId < watermark) {
+      // First paint, or the room's chat state was reset: move the
+      // watermark silently.
+      announceAfterIdRef.current = latestId
+      return
+    }
+    if (latestId > watermark) {
+      const fresh = messages.filter(m => m.messageId > watermark && m.messageId > replayUpTo)
       const last = fresh[fresh.length - 1]
-      if (last) setAnnouncement(`${last.playerId}: ${last.text}`)
+      if (last) setAnnouncement({ id: last.messageId, text: `${last.playerId}: ${last.text}` })
       announceAfterIdRef.current = latestId
     }
-  }, [latestId, messages, onSeen])
+  }, [latestId, messages, replayUpTo])
 
   const send = useCallback(() => {
     const trimmed = draft.trim()
@@ -104,8 +141,36 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
     onSeen()
   }, [onSeen])
 
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false)
+  }, [])
+
+  // Focus follows the drawer: into the composer on open, back to the
+  // toggle on close. The CSS hides whichever control had focus, which
+  // would otherwise drop keyboard users back to <body>.
+  useEffect(() => {
+    if (!docked) {
+      if (drawerOpen) inputRef.current?.focus()
+      else if (wasDrawerOpenRef.current) toggleRef.current?.focus()
+    }
+    wasDrawerOpenRef.current = drawerOpen
+  }, [drawerOpen, docked])
+
+  const onPanelKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Escape' && !docked && drawerOpen) closeDrawer()
+    },
+    [docked, drawerOpen, closeDrawer]
+  )
+
   const panel = (
-    <div className={styles.panel} data-testid="room-chat-panel">
+    <div
+      className={styles.panel}
+      data-testid="room-chat-panel"
+      role={!docked && drawerOpen ? 'dialog' : undefined}
+      aria-label="Room chat"
+      onKeyDown={onPanelKeyDown}
+    >
       <div className={styles.header}>
         <span className={styles.title}>Room chat</span>
         <span className={styles.connection}>
@@ -114,7 +179,7 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
         <button
           type="button"
           className={styles.closeButton}
-          onClick={() => setDrawerOpen(false)}
+          onClick={closeDrawer}
           aria-label="Close chat"
         >
           ×
@@ -154,6 +219,7 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
       )}
       <div className={styles.composer}>
         <textarea
+          ref={inputRef}
           className={styles.input}
           value={draft}
           onChange={event => setDraft(event.target.value)}
@@ -179,10 +245,6 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
           </button>
         </div>
       </div>
-      {/* Live messages only: the history replay never lands here. */}
-      <div className={styles.srOnly} aria-live="polite">
-        {announcement}
-      </div>
     </div>
   )
 
@@ -190,6 +252,7 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
     <div className={`${styles.chatRoot} ${drawerOpen ? styles.drawerOpen : ''}`}>
       {panel}
       <button
+        ref={toggleRef}
         type="button"
         className={styles.drawerToggle}
         onClick={openDrawer}
@@ -198,6 +261,16 @@ const RoomChat = ({ messages, playerId, unreadCount, connected, onSend, onSeen }
         💬
         {unreadCount > 0 && <span className={styles.unreadBadge}>{unreadCount}</span>}
       </button>
+      {/* Live messages only — never the history replay. Outside the
+        * panel so a closed drawer still announces; keyed by id so a
+        * repeat of identical text is still a DOM mutation. */}
+      <div className={styles.srOnly} aria-live="polite">
+        {announcement && (
+          <span key={announcement.id} data-message-id={announcement.id}>
+            {announcement.text}
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/apps/golf/components/__tests__/RoomChat.test.tsx
+++ b/src/apps/golf/components/__tests__/RoomChat.test.tsx
@@ -17,11 +17,9 @@ const msg = (messageId: number, playerId: string, text: string): ChatMessage => 
 
 const baseProps = {
   playerId: 'alice',
-  unreadCount: 0,
   connected: true,
   replayUpTo: 0,
-  onSend: vi.fn(),
-  onSeen: vi.fn()
+  onSend: vi.fn()
 }
 
 describe('RoomChat', () => {
@@ -103,20 +101,36 @@ describe('RoomChat', () => {
     expect(screen.getByText('reconnecting…')).toBeInTheDocument()
   })
 
-  it('shows the unread badge on the drawer toggle and clears via onSeen when opened', () => {
-    render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'hi')]} unreadCount={3} />)
-    const toggle = screen.getByRole('button', { name: 'Open chat, 3 unread' })
-    expect(toggle.textContent).toContain('3')
+  it('accumulates unread on the toggle while the drawer is closed and clears on open', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    rerender(
+      <RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two')]} />
+    )
+    // Hidden panel: arrivals stay unread, or the badge could never show.
+    const toggle = screen.getByRole('button', { name: 'Open chat, 2 unread' })
+    expect(toggle.textContent).toContain('2')
 
     fireEvent.click(toggle)
-    expect(baseProps.onSeen).toHaveBeenCalled()
+    // Open and following: everything is seen, the badge is gone.
+    expect(screen.getByRole('button', { name: 'Open chat' })).toBeInTheDocument()
   })
 
   it('offers a new-messages jump instead of yanking scrolled-back readers', () => {
-    render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'hi')]} unreadCount={2} />)
-    const jump = screen.getByRole('button', { name: '2 new messages' })
+    const { rerender } = render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one')]} />)
+    fireEvent.click(screen.getByRole('button', { name: /Open chat/ }))
+
+    // Scroll well away from the bottom, so the reader is not following.
+    const list = screen.getByTestId('chat-messages')
+    Object.defineProperty(list, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(list, 'clientHeight', { value: 200, configurable: true })
+    list.scrollTop = 0
+    fireEvent.scroll(list)
+
+    rerender(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two')]} />)
+    const jump = screen.getByRole('button', { name: '1 new message' })
+
     fireEvent.click(jump)
-    expect(baseProps.onSeen).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: '1 new message' })).toBeNull()
   })
 
   it('announces live messages politely but never the history replay', () => {
@@ -175,22 +189,17 @@ describe('RoomChat', () => {
     expect(second?.textContent).toBe('bob: gg')
   })
 
-  it('lets unread accumulate while the drawer is closed, marking seen only once visible', () => {
+  it('keeps arrivals seen while the drawer is open and following', () => {
     const { rerender } = render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one')]} />)
-    rerender(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two')]} />)
-    // Hidden panel: arrivals must not be marked seen, or the toggle
-    // badge could never show.
-    expect(baseProps.onSeen).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /Open chat/ }))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open chat' }))
-    expect(baseProps.onSeen).toHaveBeenCalled()
-
-    const seenWhileOpen = baseProps.onSeen.mock.calls.length
     rerender(
-      <RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two'), msg(3, 'bob', 'three')]} />
+      <RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two')]} />
     )
-    // Visible and following: the new arrival is seen immediately.
-    expect(baseProps.onSeen.mock.calls.length).toBeGreaterThan(seenWhileOpen)
+    // Visible and following: the new arrival is seen immediately — no
+    // badge when the drawer closes again.
+    fireEvent.keyDown(screen.getByLabelText('Chat message'), { key: 'Escape' })
+    expect(screen.getByRole('button', { name: 'Open chat' })).toBeInTheDocument()
   })
 
   it('moves focus into the composer on open and back to the toggle on Escape', () => {

--- a/src/apps/golf/components/__tests__/RoomChat.test.tsx
+++ b/src/apps/golf/components/__tests__/RoomChat.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import RoomChat from '../RoomChat'
+import type { ChatMessage } from '@/types/golfChat'
+
+// The chat surface itself (MoonBase#1226): literal text rendering, the
+// composer's keyboard/limit/disabled rules, and the unread affordances.
+// Scroll-following is exercised only as far as jsdom allows — the
+// near-bottom geometry itself has no layout engine here.
+
+const msg = (messageId: number, playerId: string, text: string): ChatMessage => ({
+  messageId,
+  playerId,
+  text,
+  sentAtUnixMillis: 1_700_000_000_000 + messageId
+})
+
+const baseProps = {
+  playerId: 'alice',
+  unreadCount: 0,
+  connected: true,
+  onSend: vi.fn(),
+  onSeen: vi.fn()
+}
+
+describe('RoomChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders messages chronologically with sender and a useful empty state', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    expect(screen.getByText(/No messages yet/)).toBeInTheDocument()
+
+    rerender(
+      <RoomChat
+        {...baseProps}
+        messages={[msg(1, 'bob', 'first'), msg(2, 'alice', 'second')]}
+      />
+    )
+    const list = screen.getByTestId('chat-messages')
+    expect(list.textContent).toContain('bob')
+    expect(list.textContent?.indexOf('first')).toBeLessThan(list.textContent!.indexOf('second'))
+  })
+
+  it('renders HTML-looking text as literal text, never markup', () => {
+    render(
+      <RoomChat
+        {...baseProps}
+        messages={[msg(1, 'bob', '<img src=x onerror=alert(1)>')]}
+      />
+    )
+    expect(screen.getByText('<img src=x onerror=alert(1)>')).toBeInTheDocument()
+    expect(document.querySelector('img')).toBeNull()
+  })
+
+  it('sends on Enter, newline on Shift+Enter, trimmed', () => {
+    render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+
+    fireEvent.change(input, { target: { value: '  hello  ' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+    expect(baseProps.onSend).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(baseProps.onSend).toHaveBeenCalledWith('hello')
+    // Sending clears the composer.
+    expect((input as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('refuses empty sends and keeps an over-limit draft unsent', () => {
+    render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(baseProps.onSend).not.toHaveBeenCalled()
+
+    // 501 bytes: over the server's byte limit, so the draft stays put —
+    // the user edits it down instead of losing it to a rejection.
+    const tooLong = 'a'.repeat(501)
+    fireEvent.change(input, { target: { value: tooLong } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(baseProps.onSend).not.toHaveBeenCalled()
+    expect((input as HTMLTextAreaElement).value).toBe(tooLong)
+    expect(screen.getByText('501/500')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+  })
+
+  it('counts limit bytes the way the server does', () => {
+    render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+    // 125 four-byte emoji = 500 bytes: at the limit, still sendable.
+    fireEvent.change(input, { target: { value: '🎉'.repeat(125) } })
+    expect(screen.getByText('500/500')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled()
+  })
+
+  it('disables the composer while disconnected', () => {
+    render(<RoomChat {...baseProps} messages={[]} connected={false} />)
+    expect(screen.getByLabelText('Chat message')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+    expect(screen.getByText('reconnecting…')).toBeInTheDocument()
+  })
+
+  it('shows the unread badge on the drawer toggle and clears via onSeen when opened', () => {
+    render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'hi')]} unreadCount={3} />)
+    const toggle = screen.getByRole('button', { name: 'Open chat, 3 unread' })
+    expect(toggle.textContent).toContain('3')
+
+    fireEvent.click(toggle)
+    expect(baseProps.onSeen).toHaveBeenCalled()
+  })
+
+  it('offers a new-messages jump instead of yanking scrolled-back readers', () => {
+    render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'hi')]} unreadCount={2} />)
+    const jump = screen.getByRole('button', { name: '2 new messages' })
+    fireEvent.click(jump)
+    expect(baseProps.onSeen).toHaveBeenCalled()
+  })
+
+  it('announces live messages politely but never the history replay', () => {
+    const { container, rerender } = render(
+      <RoomChat {...baseProps} messages={[msg(1, 'bob', 'replayed history')]} />
+    )
+    const live = container.querySelector('[aria-live="polite"]')
+    expect(live?.textContent).toBe('')
+
+    rerender(
+      <RoomChat
+        {...baseProps}
+        messages={[msg(1, 'bob', 'replayed history'), msg(2, 'bob', 'fresh message')]}
+      />
+    )
+    expect(live?.textContent).toBe('bob: fresh message')
+    expect(live?.textContent).not.toContain('replayed history')
+  })
+})

--- a/src/apps/golf/components/__tests__/RoomChat.test.tsx
+++ b/src/apps/golf/components/__tests__/RoomChat.test.tsx
@@ -19,6 +19,7 @@ const baseProps = {
   playerId: 'alice',
   unreadCount: 0,
   connected: true,
+  replayUpTo: 0,
   onSend: vi.fn(),
   onSeen: vi.fn()
 }
@@ -133,5 +134,72 @@ describe('RoomChat', () => {
     )
     expect(live?.textContent).toBe('bob: fresh message')
     expect(live?.textContent).not.toContain('replayed history')
+  })
+
+  it('keeps a history replay that lands after mount silent, in the real join order', () => {
+    // The integrated order: the component mounts with no messages, then
+    // the roomChatHistory frame arrives alongside its watermark.
+    const { container, rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    const live = container.querySelector('[aria-live="polite"]')
+
+    rerender(
+      <RoomChat
+        {...baseProps}
+        messages={[msg(1, 'bob', 'old one'), msg(2, 'bob', 'old two')]}
+        replayUpTo={2}
+      />
+    )
+    expect(live?.textContent).toBe('')
+
+    rerender(
+      <RoomChat
+        {...baseProps}
+        messages={[msg(1, 'bob', 'old one'), msg(2, 'bob', 'old two'), msg(3, 'bob', 'live now')]}
+        replayUpTo={2}
+      />
+    )
+    expect(live?.textContent).toBe('bob: live now')
+  })
+
+  it('re-announces a repeat of identical text as a fresh DOM node', () => {
+    // aria-live only fires on mutation: two "gg" in a row must not
+    // collapse into one silent render.
+    const { container, rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    rerender(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'gg')]} />)
+    const first = container.querySelector('[aria-live="polite"] span')
+    expect(first?.getAttribute('data-message-id')).toBe('1')
+
+    rerender(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'gg'), msg(2, 'bob', 'gg')]} />)
+    const second = container.querySelector('[aria-live="polite"] span')
+    expect(second?.getAttribute('data-message-id')).toBe('2')
+    expect(second?.textContent).toBe('bob: gg')
+  })
+
+  it('lets unread accumulate while the drawer is closed, marking seen only once visible', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one')]} />)
+    rerender(<RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two')]} />)
+    // Hidden panel: arrivals must not be marked seen, or the toggle
+    // badge could never show.
+    expect(baseProps.onSeen).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    expect(baseProps.onSeen).toHaveBeenCalled()
+
+    const seenWhileOpen = baseProps.onSeen.mock.calls.length
+    rerender(
+      <RoomChat {...baseProps} messages={[msg(1, 'bob', 'one'), msg(2, 'bob', 'two'), msg(3, 'bob', 'three')]} />
+    )
+    // Visible and following: the new arrival is seen immediately.
+    expect(baseProps.onSeen.mock.calls.length).toBeGreaterThan(seenWhileOpen)
+  })
+
+  it('moves focus into the composer on open and back to the toggle on Escape', () => {
+    render(<RoomChat {...baseProps} messages={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open chat' }))
+    const input = screen.getByLabelText('Chat message')
+    expect(document.activeElement).toBe(input)
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Open chat' }))
   })
 })

--- a/src/hooks/__tests__/useGolfGame.chat.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.chat.test.tsx
@@ -180,6 +180,26 @@ describe('useGolfGame - room chat', () => {
     expect(result.current.chatMessages[0].messageId).toBe(11)
   })
 
+  it('tracks the replay watermark from history only, and scopes it to the room', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
+    })
+    expect(result.current.chatReplayUpTo).toBe(2)
+
+    // Live messages never raise it — they are the ones to announce.
+    act(() => {
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(3))
+    })
+    expect(result.current.chatReplayUpTo).toBe(2)
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM02'))
+    })
+    expect(result.current.chatReplayUpTo).toBe(0)
+  })
+
   it('trims before sending and refuses whitespace-only drafts', () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper })
     act(() => result.current.sendChat('  good luck  '))

--- a/src/hooks/__tests__/useGolfGame.chat.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.chat.test.tsx
@@ -7,7 +7,8 @@ import type { ChatMessage } from '@/types/golfChat'
 import { CHAT_HISTORY_LIMIT } from '@/types/golfChat'
 
 // Room chat state in the hook (MoonBase#1226): merge by messageId across
-// history and live, unread transitions, room scoping, and the send path.
+// history and live, the replay watermark, room scoping, and the send
+// path. Seen/unread is presentation state and is tested on RoomChat.
 
 const mockNetworkAdapter = {
   connect: vi.fn(),
@@ -90,7 +91,6 @@ describe('useGolfGame - room chat', () => {
   it('starts empty with the capability reported from the adapter', () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper })
     expect(result.current.chatMessages).toEqual([])
-    expect(result.current.chatUnreadCount).toBe(0)
     expect(result.current.chatAvailable).toBe(true)
   })
 
@@ -106,44 +106,18 @@ describe('useGolfGame - room chat', () => {
     expect(result.current.chatMessages.map(m => m.messageId)).toEqual([1, 2, 3, 4])
   })
 
-  it('counts unread until marked seen, then counts only newer arrivals', () => {
-    const { result } = renderHook(() => useGolfGame(), { wrapper })
-    act(() => {
-      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
-    })
-    expect(result.current.chatUnreadCount).toBe(2)
-
-    act(() => result.current.markChatSeen())
-    expect(result.current.chatUnreadCount).toBe(0)
-
-    act(() => {
-      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(3))
-    })
-    expect(result.current.chatUnreadCount).toBe(1)
-
-    // A duplicate delivery of an already-seen id changes nothing.
-    act(() => {
-      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(2))
-    })
-    expect(result.current.chatUnreadCount).toBe(1)
-  })
-
   it('keeps chat across a resume into the same room, deduplicating the replay', () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper })
     act(() => {
       mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
       mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
     })
-    // Separate act: markChatSeen reads the rendered message list, the
-    // way the component invokes it after paint.
-    act(() => result.current.markChatSeen())
     act(() => {
       // Reconnect: the same room announces again and replays history.
       mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
       mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2), msg(3)])
     })
     expect(result.current.chatMessages.map(m => m.messageId)).toEqual([1, 2, 3])
-    expect(result.current.chatUnreadCount).toBe(1)
   })
 
   it('drops the previous room chat when a different room is joined', () => {
@@ -156,10 +130,9 @@ describe('useGolfGame - room chat', () => {
       mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM02'))
     })
     expect(result.current.chatMessages).toEqual([])
-    expect(result.current.chatUnreadCount).toBe(0)
   })
 
-  it('clears chat and unread on leaveRoom', () => {
+  it('clears chat on leaveRoom', () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper })
     act(() => {
       mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
@@ -167,7 +140,6 @@ describe('useGolfGame - room chat', () => {
     })
     act(() => result.current.leaveRoom())
     expect(result.current.chatMessages).toEqual([])
-    expect(result.current.chatUnreadCount).toBe(0)
   })
 
   it('caps the retained view at the server limit', () => {

--- a/src/hooks/__tests__/useGolfGame.chat.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.chat.test.tsx
@@ -30,8 +30,8 @@ const mockNetworkAdapter = {
   hideCards: vi.fn(),
   isMyTurn: vi.fn(),
   getCurrentPlayer: vi.fn(),
-  // The chat capability: present on this mock the way the v2 adapter
-  // provides it, so chatAvailable resolves true.
+  // Declared the way the v2 adapter does; the send path forwards here.
+  // Availability is proven by wire events, not by this declaration.
   sendChat: vi.fn(),
   roomState: null,
   _callbacks: null as {
@@ -88,10 +88,34 @@ describe('useGolfGame - room chat', () => {
     mockNetworkAdapter._callbacks = null
   })
 
-  it('starts empty with the capability reported from the adapter', () => {
+  it('reveals chat only once the wire delivers it', () => {
     const { result } = renderHook(() => useGolfGame(), { wrapper })
+    // The adapter class declaring sendChat is not proof the server has
+    // chat: a UI deployed ahead of the server must render no chat UI.
+    expect(result.current.chatAvailable).toBe(false)
     expect(result.current.chatMessages).toEqual([])
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      // An empty replay is still proof: quiet rooms have chat too.
+      mockNetworkAdapter._callbacks?.onChatHistory?.([])
+    })
     expect(result.current.chatAvailable).toBe(true)
+  })
+
+  it('re-proves the capability per room', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      // A live message committing during the join is proof too.
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(1))
+    })
+    expect(result.current.chatAvailable).toBe(true)
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM02'))
+    })
+    expect(result.current.chatAvailable).toBe(false)
   })
 
   it('merges history and live by id, in id order', () => {

--- a/src/hooks/__tests__/useGolfGame.chat.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.chat.test.tsx
@@ -1,0 +1,191 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BrowserRouter } from 'react-router-dom'
+import { useGolfGame } from '../useGolfGame'
+import type { Room } from '@/types/golf'
+import type { ChatMessage } from '@/types/golfChat'
+import { CHAT_HISTORY_LIMIT } from '@/types/golfChat'
+
+// Room chat state in the hook (MoonBase#1226): merge by messageId across
+// history and live, unread transitions, room scoping, and the send path.
+
+const mockNetworkAdapter = {
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  createRoom: vi.fn(),
+  createGame: vi.fn(),
+  joinRoom: vi.fn(),
+  joinGame: vi.fn(),
+  leaveRoom: vi.fn(),
+  startGame: vi.fn(),
+  startNewGame: vi.fn(),
+  leaveGame: vi.fn(),
+  peekCard: vi.fn(),
+  drawCard: vi.fn(),
+  takeFromDiscard: vi.fn(),
+  swapCard: vi.fn(),
+  discardDrawn: vi.fn(),
+  knock: vi.fn(),
+  hideCards: vi.fn(),
+  isMyTurn: vi.fn(),
+  getCurrentPlayer: vi.fn(),
+  // The chat capability: present on this mock the way the v2 adapter
+  // provides it, so chatAvailable resolves true.
+  sendChat: vi.fn(),
+  roomState: null,
+  _callbacks: null as {
+    onRoomJoined?: (playerId: string, roomState: Room) => void
+    onChatMessage?: (message: ChatMessage) => void
+    onChatHistory?: (messages: ChatMessage[]) => void
+  } | null
+}
+
+vi.mock('@/utils/networkAdapter', () => ({
+  GolfNetworkAdapter: vi.fn().mockImplementation(function (callbacks) {
+    mockNetworkAdapter._callbacks = callbacks
+    return mockNetworkAdapter
+  })
+}))
+
+vi.mock('@/utils/golfPermalinks', () => ({
+  generateRoomPermalink: (roomId: string) => `/golf/room/${roomId}`,
+  generateGamePermalink: (roomId: string, gameId: string) => `/golf/room/${roomId}/game/${gameId}`
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  }
+})
+
+const makeRoom = (id: string): Room => ({
+  id,
+  players: [],
+  games: {},
+  gameHistory: [],
+  createdAt: '',
+  lastActivity: ''
+})
+
+const msg = (messageId: number, text = `m${messageId}`): ChatMessage => ({
+  messageId,
+  playerId: 'bob',
+  text,
+  sentAtUnixMillis: 1_700_000_000_000 + messageId
+})
+
+describe('useGolfGame - room chat', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <BrowserRouter>{children}</BrowserRouter>
+  )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNetworkAdapter._callbacks = null
+  })
+
+  it('starts empty with the capability reported from the adapter', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    expect(result.current.chatMessages).toEqual([])
+    expect(result.current.chatUnreadCount).toBe(0)
+    expect(result.current.chatAvailable).toBe(true)
+  })
+
+  it('merges history and live by id, in id order', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      // Live lands first — a message committing during the join — then
+      // the replay that also contains it.
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(3))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2), msg(3)])
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(4))
+    })
+    expect(result.current.chatMessages.map(m => m.messageId)).toEqual([1, 2, 3, 4])
+  })
+
+  it('counts unread until marked seen, then counts only newer arrivals', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
+    })
+    expect(result.current.chatUnreadCount).toBe(2)
+
+    act(() => result.current.markChatSeen())
+    expect(result.current.chatUnreadCount).toBe(0)
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(3))
+    })
+    expect(result.current.chatUnreadCount).toBe(1)
+
+    // A duplicate delivery of an already-seen id changes nothing.
+    act(() => {
+      mockNetworkAdapter._callbacks?.onChatMessage?.(msg(2))
+    })
+    expect(result.current.chatUnreadCount).toBe(1)
+  })
+
+  it('keeps chat across a resume into the same room, deduplicating the replay', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
+    })
+    // Separate act: markChatSeen reads the rendered message list, the
+    // way the component invokes it after paint.
+    act(() => result.current.markChatSeen())
+    act(() => {
+      // Reconnect: the same room announces again and replays history.
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2), msg(3)])
+    })
+    expect(result.current.chatMessages.map(m => m.messageId)).toEqual([1, 2, 3])
+    expect(result.current.chatUnreadCount).toBe(1)
+  })
+
+  it('drops the previous room chat when a different room is joined', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1), msg(2)])
+    })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM02'))
+    })
+    expect(result.current.chatMessages).toEqual([])
+    expect(result.current.chatUnreadCount).toBe(0)
+  })
+
+  it('clears chat and unread on leaveRoom', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+      mockNetworkAdapter._callbacks?.onChatHistory?.([msg(1)])
+    })
+    act(() => result.current.leaveRoom())
+    expect(result.current.chatMessages).toEqual([])
+    expect(result.current.chatUnreadCount).toBe(0)
+  })
+
+  it('caps the retained view at the server limit', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    const flood = Array.from({ length: CHAT_HISTORY_LIMIT + 10 }, (_, i) => msg(i + 1))
+    act(() => {
+      mockNetworkAdapter._callbacks?.onChatHistory?.(flood)
+    })
+    expect(result.current.chatMessages).toHaveLength(CHAT_HISTORY_LIMIT)
+    expect(result.current.chatMessages[0].messageId).toBe(11)
+  })
+
+  it('trims before sending and refuses whitespace-only drafts', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    act(() => result.current.sendChat('  good luck  '))
+    expect(mockNetworkAdapter.sendChat).toHaveBeenCalledWith('good luck')
+
+    act(() => result.current.sendChat('   '))
+    expect(mockNetworkAdapter.sendChat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -1,6 +1,8 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { GameState, Player, Room } from '@/types/golf'
+import type { ChatMessage } from '@/types/golfChat'
+import { mergeChatMessages } from '@/types/golfChat'
 import { GolfNetworkAdapter } from '@/utils/networkAdapter'
 import { GolfV2NetworkAdapter } from '@/utils/golfV2Adapter'
 import { isGolfV2Enabled } from '@/utils/golfV2'
@@ -31,6 +33,15 @@ interface UseGolfGameReturn {
   winner: string | null
   winners: string[] | null
   finalScores: Array<{ playerName: string; score: number }> | null
+
+  // Room chat (MoonBase#1226): the room's merged history+live view,
+  // capped at 100 by the shared merge. Available only when the active
+  // adapter's wire carries chat (v2); v1 renders no chat UI.
+  chatMessages: ChatMessage[]
+  chatUnreadCount: number
+  chatAvailable: boolean
+  sendChat: (text: string) => void
+  markChatSeen: () => void
   
   // New game notifications
   newGameNotifications: Array<{
@@ -111,6 +122,12 @@ export const useGolfGame = ({
     error: null as string | null,
     gameJoinAttempted: false
   })
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
+  const [chatLastSeenId, setChatLastSeenId] = useState(0)
+  const [chatAvailable, setChatAvailable] = useState(false)
+  // The room the chat state belongs to: entering a different room drops
+  // the old room's messages before its history lands.
+  const chatRoomRef = useRef<string | null>(null)
   const [isReconnecting, setIsReconnecting] = useState(false)
   const [isManualNavigation, setIsManualNavigation] = useState(false)
   const [, setIsCreatingNewGame] = useState(false)
@@ -306,6 +323,10 @@ export const useGolfGame = ({
     if (roomState?.id) {
       networkAdapterRef.current?.leaveRoom(roomState.id)
     }
+    // Chat belongs to the room: leaving clears messages and unread state.
+    chatRoomRef.current = null
+    setChatMessages([])
+    setChatLastSeenId(0)
     setRoomState(null)
     setGameState(null)
     setIsInRoom(false)
@@ -426,7 +447,22 @@ export const useGolfGame = ({
     joinGame(gameId)
   }, [roomState?.id, dismissNewGameNotification, joinGame, showNotification])
 
+  const sendChat = useCallback((text: string) => {
+    const adapter = networkAdapterRef.current
+    // Trim here so what the byte counter measured is what ships; the
+    // server validates again and rejects what a stale client sends.
+    const trimmed = text.trim()
+    if (!adapter?.sendChat || !trimmed) return
+    adapter.sendChat(trimmed)
+  }, [])
+
+  const markChatSeen = useCallback(() => {
+    const latest = chatMessages.length > 0 ? chatMessages[chatMessages.length - 1].messageId : 0
+    setChatLastSeenId(prev => Math.max(prev, latest))
+  }, [chatMessages])
+
   // Computed values
+  const chatUnreadCount = chatMessages.filter(m => m.messageId > chatLastSeenId).length
   const currentPlayer = gameState?.players.find(p => p.id === playerId)
   const isMyTurn = gameState?.players[gameState.currentPlayerIndex]?.id === playerId
 
@@ -444,6 +480,14 @@ export const useGolfGame = ({
         }, 2000)
       },
       onRoomJoined: (newPlayerId, newRoomState) => {
+        // A different room means different chat: drop the old room's
+        // messages before the new room's history event lands. A resume
+        // into the same room keeps them — its replay merges by id.
+        if (chatRoomRef.current !== newRoomState.id) {
+          chatRoomRef.current = newRoomState.id
+          setChatMessages([])
+          setChatLastSeenId(0)
+        }
         setIsReconnecting(false)
         if (reconnectTimeoutRef.current) {
           clearTimeout(reconnectTimeoutRef.current)
@@ -531,6 +575,12 @@ export const useGolfGame = ({
           }
         }
       },
+      onChatMessage: (message) => {
+        setChatMessages(prev => mergeChatMessages(prev, [message]))
+      },
+      onChatHistory: (messages) => {
+        setChatMessages(prev => mergeChatMessages(prev, messages))
+      },
       onGameError: (errorMessage) => {
         if (permalinkJoinAttempt.isAttempting &&
             (errorMessage.includes('not found') || errorMessage.includes('does not exist'))) {
@@ -587,6 +637,9 @@ export const useGolfGame = ({
     })
 
     networkAdapterRef.current = adapter
+    // Through the shared interface: the v1 class doesn't declare the
+    // optional capability at all.
+    setChatAvailable(typeof networkAdapterRef.current.sendChat === 'function')
 
     // Connect to server (the v2 adapter resolves its own endpoints)
     const websocketUrl = import.meta.env.VITE_GOLF_WEBSOCKET_URL || 'wss://api.muchq.com/games/v1/golf-ws'
@@ -826,7 +879,14 @@ export const useGolfGame = ({
     winner,
     winners,
     finalScores,
-  
+
+    // Room chat
+    chatMessages,
+    chatUnreadCount,
+    chatAvailable,
+    sendChat,
+    markChatSeen,
+
     // New game notifications
     newGameNotifications,
     

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -40,6 +40,9 @@ interface UseGolfGameReturn {
   chatMessages: ChatMessage[]
   chatUnreadCount: number
   chatAvailable: boolean
+  // Highest messageId ever delivered via a history replay: consumers
+  // that announce live messages use it to keep replays silent.
+  chatReplayUpTo: number
   sendChat: (text: string) => void
   markChatSeen: () => void
   
@@ -124,6 +127,7 @@ export const useGolfGame = ({
   })
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
   const [chatLastSeenId, setChatLastSeenId] = useState(0)
+  const [chatReplayUpTo, setChatReplayUpTo] = useState(0)
   const [chatAvailable, setChatAvailable] = useState(false)
   // The room the chat state belongs to: entering a different room drops
   // the old room's messages before its history lands.
@@ -327,6 +331,7 @@ export const useGolfGame = ({
     chatRoomRef.current = null
     setChatMessages([])
     setChatLastSeenId(0)
+    setChatReplayUpTo(0)
     setRoomState(null)
     setGameState(null)
     setIsInRoom(false)
@@ -487,6 +492,7 @@ export const useGolfGame = ({
           chatRoomRef.current = newRoomState.id
           setChatMessages([])
           setChatLastSeenId(0)
+          setChatReplayUpTo(0)
         }
         setIsReconnecting(false)
         if (reconnectTimeoutRef.current) {
@@ -580,6 +586,9 @@ export const useGolfGame = ({
       },
       onChatHistory: (messages) => {
         setChatMessages(prev => mergeChatMessages(prev, messages))
+        // Same commit as the merge, so consumers never see replayed
+        // messages without the watermark that keeps them unannounced.
+        setChatReplayUpTo(prev => messages.reduce((max, m) => Math.max(max, m.messageId), prev))
       },
       onGameError: (errorMessage) => {
         if (permalinkJoinAttempt.isAttempting &&
@@ -884,6 +893,7 @@ export const useGolfGame = ({
     chatMessages,
     chatUnreadCount,
     chatAvailable,
+    chatReplayUpTo,
     sendChat,
     markChatSeen,
 

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -36,15 +36,15 @@ interface UseGolfGameReturn {
 
   // Room chat (MoonBase#1226): the room's merged history+live view,
   // capped at 100 by the shared merge. Available only when the active
-  // adapter's wire carries chat (v2); v1 renders no chat UI.
+  // adapter's wire carries chat (v2); v1 renders no chat UI. Seen and
+  // unread are presentation state and live in the chat UI — this hook
+  // only owns what the wire knows.
   chatMessages: ChatMessage[]
-  chatUnreadCount: number
   chatAvailable: boolean
   // Highest messageId ever delivered via a history replay: consumers
   // that announce live messages use it to keep replays silent.
   chatReplayUpTo: number
   sendChat: (text: string) => void
-  markChatSeen: () => void
   
   // New game notifications
   newGameNotifications: Array<{
@@ -126,12 +126,16 @@ export const useGolfGame = ({
     gameJoinAttempted: false
   })
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
-  const [chatLastSeenId, setChatLastSeenId] = useState(0)
   const [chatReplayUpTo, setChatReplayUpTo] = useState(0)
   const [chatAvailable, setChatAvailable] = useState(false)
   // The room the chat state belongs to: entering a different room drops
   // the old room's messages before its history lands.
   const chatRoomRef = useRef<string | null>(null)
+  const resetChat = useCallback((roomId: string | null) => {
+    chatRoomRef.current = roomId
+    setChatMessages([])
+    setChatReplayUpTo(0)
+  }, [])
   const [isReconnecting, setIsReconnecting] = useState(false)
   const [isManualNavigation, setIsManualNavigation] = useState(false)
   const [, setIsCreatingNewGame] = useState(false)
@@ -327,11 +331,8 @@ export const useGolfGame = ({
     if (roomState?.id) {
       networkAdapterRef.current?.leaveRoom(roomState.id)
     }
-    // Chat belongs to the room: leaving clears messages and unread state.
-    chatRoomRef.current = null
-    setChatMessages([])
-    setChatLastSeenId(0)
-    setChatReplayUpTo(0)
+    // Chat belongs to the room: leaving clears it.
+    resetChat(null)
     setRoomState(null)
     setGameState(null)
     setIsInRoom(false)
@@ -342,7 +343,7 @@ export const useGolfGame = ({
     setSelectedCardIndex(null)
     setNewGameNotifications([])
     navigate('/golf', { replace: true })
-  }, [roomState?.id, navigate])
+  }, [roomState?.id, navigate, resetChat])
 
   // Navigation helper functions
   const navigateToRoom = useCallback((roomId: string) => {
@@ -461,13 +462,7 @@ export const useGolfGame = ({
     adapter.sendChat(trimmed)
   }, [])
 
-  const markChatSeen = useCallback(() => {
-    const latest = chatMessages.length > 0 ? chatMessages[chatMessages.length - 1].messageId : 0
-    setChatLastSeenId(prev => Math.max(prev, latest))
-  }, [chatMessages])
-
   // Computed values
-  const chatUnreadCount = chatMessages.filter(m => m.messageId > chatLastSeenId).length
   const currentPlayer = gameState?.players.find(p => p.id === playerId)
   const isMyTurn = gameState?.players[gameState.currentPlayerIndex]?.id === playerId
 
@@ -489,10 +484,7 @@ export const useGolfGame = ({
         // messages before the new room's history event lands. A resume
         // into the same room keeps them — its replay merges by id.
         if (chatRoomRef.current !== newRoomState.id) {
-          chatRoomRef.current = newRoomState.id
-          setChatMessages([])
-          setChatLastSeenId(0)
-          setChatReplayUpTo(0)
+          resetChat(newRoomState.id)
         }
         setIsReconnecting(false)
         if (reconnectTimeoutRef.current) {
@@ -891,11 +883,9 @@ export const useGolfGame = ({
 
     // Room chat
     chatMessages,
-    chatUnreadCount,
     chatAvailable,
     chatReplayUpTo,
     sendChat,
-    markChatSeen,
 
     // New game notifications
     newGameNotifications,

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -35,11 +35,15 @@ interface UseGolfGameReturn {
   finalScores: Array<{ playerName: string; score: number }> | null
 
   // Room chat (MoonBase#1226): the room's merged history+live view,
-  // capped at 100 by the shared merge. Available only when the active
-  // adapter's wire carries chat (v2); v1 renders no chat UI. Seen and
-  // unread are presentation state and live in the chat UI — this hook
-  // only owns what the wire knows.
+  // capped at 100 by the shared merge. Seen and unread are presentation
+  // state and live in the chat UI — this hook only owns what the wire
+  // knows.
   chatMessages: ChatMessage[]
+  // True once the current room's wire has actually delivered chat — the
+  // join replay (empty counts) or a live message. The adapter class
+  // declaring sendChat is not proof the server has chat: a UI deployed
+  // ahead of the server (or after a rollback) must render no chat at
+  // all rather than a composer whose sends silently vanish.
   chatAvailable: boolean
   // Highest messageId ever delivered via a history replay: consumers
   // that announce live messages use it to keep replays silent.
@@ -135,6 +139,9 @@ export const useGolfGame = ({
     chatRoomRef.current = roomId
     setChatMessages([])
     setChatReplayUpTo(0)
+    // Capability is re-proven per room: the next replay or live message
+    // flips it back.
+    setChatAvailable(false)
   }, [])
   const [isReconnecting, setIsReconnecting] = useState(false)
   const [isManualNavigation, setIsManualNavigation] = useState(false)
@@ -574,9 +581,13 @@ export const useGolfGame = ({
         }
       },
       onChatMessage: (message) => {
+        setChatAvailable(true)
         setChatMessages(prev => mergeChatMessages(prev, [message]))
       },
       onChatHistory: (messages) => {
+        // The replay is the wire's proof that chat exists — an empty
+        // room sends an empty one, so availability flips regardless.
+        setChatAvailable(true)
         setChatMessages(prev => mergeChatMessages(prev, messages))
         // Same commit as the merge, so consumers never see replayed
         // messages without the watermark that keeps them unannounced.
@@ -638,9 +649,6 @@ export const useGolfGame = ({
     })
 
     networkAdapterRef.current = adapter
-    // Through the shared interface: the v1 class doesn't declare the
-    // optional capability at all.
-    setChatAvailable(typeof networkAdapterRef.current.sendChat === 'function')
 
     // Connect to server (the v2 adapter resolves its own endpoints)
     const websocketUrl = import.meta.env.VITE_GOLF_WEBSOCKET_URL || 'wss://api.muchq.com/games/v1/golf-ws'

--- a/src/types/__tests__/golfChat.test.ts
+++ b/src/types/__tests__/golfChat.test.ts
@@ -3,6 +3,7 @@ import {
   CHAT_HISTORY_LIMIT,
   CHAT_TEXT_BYTE_LIMIT,
   chatTextBytes,
+  isChatMessage,
   mergeChatMessages,
   type ChatMessage
 } from '../golfChat'
@@ -58,6 +59,21 @@ describe('mergeChatMessages', () => {
 
   it('keeps empty inputs cheap and empty', () => {
     expect(mergeChatMessages([], [])).toEqual([])
+  })
+
+  it('returns the existing array unchanged when a delivery adds nothing', () => {
+    // Same identity, not just same content: state setters bail out and
+    // nothing downstream re-renders for a pure duplicate replay.
+    const messages = [msg(1), msg(2)]
+    expect(mergeChatMessages(messages, [msg(1), msg(2)])).toBe(messages)
+  })
+})
+
+describe('isChatMessage', () => {
+  it('accepts only rows with a numeric messageId', () => {
+    expect(isChatMessage(msg(1))).toBe(true)
+    const legacy = { playerId: 'bob', text: 'from an old server' }
+    expect(isChatMessage(legacy)).toBe(false)
   })
 })
 

--- a/src/types/__tests__/golfChat.test.ts
+++ b/src/types/__tests__/golfChat.test.ts
@@ -3,7 +3,6 @@ import {
   CHAT_HISTORY_LIMIT,
   CHAT_TEXT_BYTE_LIMIT,
   chatTextBytes,
-  isChatMessage,
   mergeChatMessages,
   type ChatMessage
 } from '../golfChat'
@@ -66,14 +65,6 @@ describe('mergeChatMessages', () => {
     // nothing downstream re-renders for a pure duplicate replay.
     const messages = [msg(1), msg(2)]
     expect(mergeChatMessages(messages, [msg(1), msg(2)])).toBe(messages)
-  })
-})
-
-describe('isChatMessage', () => {
-  it('accepts only rows with a numeric messageId', () => {
-    expect(isChatMessage(msg(1))).toBe(true)
-    const legacy = { playerId: 'bob', text: 'from an old server' }
-    expect(isChatMessage(legacy)).toBe(false)
   })
 })
 

--- a/src/types/__tests__/golfChat.test.ts
+++ b/src/types/__tests__/golfChat.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CHAT_HISTORY_LIMIT,
+  CHAT_TEXT_BYTE_LIMIT,
+  chatTextBytes,
+  mergeChatMessages,
+  type ChatMessage
+} from '../golfChat'
+
+// The merge rule every chat consumer applies (MoonBase#1226): messageId
+// is the only identity and the only order; arrival order and timestamps
+// decide nothing.
+
+const msg = (messageId: number, text = `m${messageId}`): ChatMessage => ({
+  messageId,
+  playerId: 'alice',
+  text,
+  sentAtUnixMillis: 1_700_000_000_000 + messageId
+})
+
+describe('mergeChatMessages', () => {
+  it('merges history and live overlap to one copy per id', () => {
+    // A message committing during a join legally arrives in both the
+    // history replay and live delivery.
+    const history = [msg(1), msg(2), msg(3)]
+    const live = [msg(3), msg(4)]
+    const merged = mergeChatMessages(history, live)
+    expect(merged.map(m => m.messageId)).toEqual([1, 2, 3, 4])
+  })
+
+  it('orders by messageId regardless of arrival order', () => {
+    const merged = mergeChatMessages([msg(5)], [msg(2), msg(9), msg(1)])
+    expect(merged.map(m => m.messageId)).toEqual([1, 2, 5, 9])
+  })
+
+  it('is idempotent for duplicate deliveries', () => {
+    // At-least-once: a reconnect can replay everything already seen.
+    const messages = [msg(1), msg(2)]
+    const merged = mergeChatMessages(mergeChatMessages(messages, messages), messages)
+    expect(merged.map(m => m.messageId)).toEqual([1, 2])
+  })
+
+  it('live before history converges the same way', () => {
+    // A live row can land before the join's replay is processed.
+    const merged = mergeChatMessages([msg(4)], [msg(1), msg(2), msg(3), msg(4)])
+    expect(merged.map(m => m.messageId)).toEqual([1, 2, 3, 4])
+  })
+
+  it('caps at the newest CHAT_HISTORY_LIMIT messages', () => {
+    // The server retains 100; a client holding more is holding rows the
+    // server already pruned.
+    const many = Array.from({ length: CHAT_HISTORY_LIMIT + 5 }, (_, i) => msg(i + 1))
+    const merged = mergeChatMessages([], many)
+    expect(merged).toHaveLength(CHAT_HISTORY_LIMIT)
+    expect(merged[0].messageId).toBe(6)
+    expect(merged[merged.length - 1].messageId).toBe(CHAT_HISTORY_LIMIT + 5)
+  })
+
+  it('keeps empty inputs cheap and empty', () => {
+    expect(mergeChatMessages([], [])).toEqual([])
+  })
+})
+
+describe('chatTextBytes', () => {
+  it('counts bytes, not characters, matching the server limit', () => {
+    expect(chatTextBytes('abc')).toBe(3)
+    // é is two UTF-8 bytes; 🎉 is four.
+    expect(chatTextBytes('é')).toBe(2)
+    expect(chatTextBytes('🎉')).toBe(4)
+    expect(CHAT_TEXT_BYTE_LIMIT).toBe(500)
+  })
+})

--- a/src/types/golfAdapter.ts
+++ b/src/types/golfAdapter.ts
@@ -7,8 +7,10 @@ import type { ChatMessage } from './golfChat'
 // fact rather than two surfaces trusted to stay identical.
 //
 // Room chat (MoonBase#1226) is a v2-only capability: the v1 wire never
-// carried it, so sendChat and the chat callbacks are optional and the
-// UI renders chat only when the active adapter provides sendChat.
+// carried it, so sendChat and the chat callbacks are optional. The UI
+// reveals chat only after the wire actually delivers it (the join
+// replay or a live message) — an adapter declaring sendChat is not
+// proof the connected server has chat.
 
 export interface GolfAdapterCallbacks {
   onRoomJoined?: (playerId: string, roomState: Room) => void

--- a/src/types/golfAdapter.ts
+++ b/src/types/golfAdapter.ts
@@ -1,9 +1,14 @@
 import type { GameState, Room, FinalScore, Player } from './golf'
+import type { ChatMessage } from './golfChat'
 
 // The one adapter contract useGolfGame depends on. Both the v1
 // GolfNetworkAdapter and the v2 GolfV2NetworkAdapter implement this, so
 // the "?golf=v2 swaps the wire, not the UI" premise is a compile-time
 // fact rather than two surfaces trusted to stay identical.
+//
+// Room chat (MoonBase#1226) is a v2-only capability: the v1 wire never
+// carried it, so sendChat and the chat callbacks are optional and the
+// UI renders chat only when the active adapter provides sendChat.
 
 export interface GolfAdapterCallbacks {
   onRoomJoined?: (playerId: string, roomState: Room) => void
@@ -16,6 +21,12 @@ export interface GolfAdapterCallbacks {
   onNewGameStarted?: (gameId: string, previousGameId?: string) => void
   onReconnecting?: () => void
   onGameError?: (message: string) => void
+  // One live message, exactly as the server committed it. May overlap
+  // onChatHistory — consumers merge by messageId, never by arrival.
+  onChatMessage?: (message: ChatMessage) => void
+  // The room's retained history (ascending, at most 100), sent once per
+  // join or resume. Replaces nothing by itself: merge, don't assign.
+  onChatHistory?: (messages: ChatMessage[]) => void
 }
 
 export interface GolfGameAdapter {
@@ -43,4 +54,8 @@ export interface GolfGameAdapter {
   hideCards(): void
   isMyTurn(): boolean
   getCurrentPlayer(): Player | null
+
+  // Absent on adapters whose wire has no chat (v1). The server trims,
+  // validates, and authorizes; this only ships the text.
+  sendChat?(text: string): void
 }

--- a/src/types/golfChat.ts
+++ b/src/types/golfChat.ts
@@ -23,13 +23,6 @@ const encoder = new TextEncoder()
 
 export const chatTextBytes = (text: string): number => encoder.encode(text).length
 
-// The wire predicate for a mergeable chat row: without a numeric
-// messageId there is no identity to merge or order on. Adapters use it
-// to keep pre-chat-id server frames out of typed chat state.
-export const isChatMessage = (
-  message: { playerId: string; text: string; messageId?: number }
-): message is ChatMessage => typeof message.messageId === 'number'
-
 // One sorted, deduplicated view of everything seen so far, capped to the
 // newest CHAT_HISTORY_LIMIT. messageId is the only ordering key — the
 // timestamp is wall-clock and display-only. Handles every arrival shape

--- a/src/types/golfChat.ts
+++ b/src/types/golfChat.ts
@@ -19,7 +19,16 @@ export const CHAT_HISTORY_LIMIT = 100
 // server does (bytes, not characters) so the warning matches the wire.
 export const CHAT_TEXT_BYTE_LIMIT = 500
 
-export const chatTextBytes = (text: string): number => new TextEncoder().encode(text).length
+const encoder = new TextEncoder()
+
+export const chatTextBytes = (text: string): number => encoder.encode(text).length
+
+// The wire predicate for a mergeable chat row: without a numeric
+// messageId there is no identity to merge or order on. Adapters use it
+// to keep pre-chat-id server frames out of typed chat state.
+export const isChatMessage = (
+  message: { playerId: string; text: string; messageId?: number }
+): message is ChatMessage => typeof message.messageId === 'number'
 
 // One sorted, deduplicated view of everything seen so far, capped to the
 // newest CHAT_HISTORY_LIMIT. messageId is the only ordering key — the
@@ -27,13 +36,25 @@ export const chatTextBytes = (text: string): number => new TextEncoder().encode(
 // the wire permits: history then live, live before history (a message
 // committing during a join arrives in both), duplicates from reconnect
 // replays, and out-of-order delivery across those paths.
+//
+// A delivery that adds nothing (a reconnect replaying only known ids)
+// returns `existing` unchanged, so state setters bail out instead of
+// re-rendering; the server never rewrites a committed id, so the copy
+// already held is the message.
 export function mergeChatMessages(
   existing: ChatMessage[],
   incoming: ChatMessage[]
 ): ChatMessage[] {
   const byId = new Map<number, ChatMessage>()
   for (const message of existing) byId.set(message.messageId, message)
-  for (const message of incoming) byId.set(message.messageId, message)
+  let added = false
+  for (const message of incoming) {
+    if (!byId.has(message.messageId)) {
+      byId.set(message.messageId, message)
+      added = true
+    }
+  }
+  if (!added) return existing
   const merged = [...byId.values()].sort((a, b) => a.messageId - b.messageId)
   return merged.length > CHAT_HISTORY_LIMIT ? merged.slice(merged.length - CHAT_HISTORY_LIMIT) : merged
 }

--- a/src/types/golfChat.ts
+++ b/src/types/golfChat.ts
@@ -1,0 +1,39 @@
+// Room chat over the golf v2 wire (MoonBase#1226): the shared message
+// shape and the merge rule every consumer applies. The server is
+// authoritative for ids, sender, and timestamp; delivery is
+// at-least-once and history/live overlap is legal, so everything that
+// accumulates messages must merge by messageId — never by arrival.
+
+export interface ChatMessage {
+  messageId: number
+  playerId: string
+  text: string
+  sentAtUnixMillis: number
+}
+
+// Mirrors the server's retention: rooms keep their newest 100 messages,
+// so a client holding more is holding rows the server already pruned.
+export const CHAT_HISTORY_LIMIT = 100
+
+// Mirrors the server's byte limit; the composer counts the same way the
+// server does (bytes, not characters) so the warning matches the wire.
+export const CHAT_TEXT_BYTE_LIMIT = 500
+
+export const chatTextBytes = (text: string): number => new TextEncoder().encode(text).length
+
+// One sorted, deduplicated view of everything seen so far, capped to the
+// newest CHAT_HISTORY_LIMIT. messageId is the only ordering key — the
+// timestamp is wall-clock and display-only. Handles every arrival shape
+// the wire permits: history then live, live before history (a message
+// committing during a join arrives in both), duplicates from reconnect
+// replays, and out-of-order delivery across those paths.
+export function mergeChatMessages(
+  existing: ChatMessage[],
+  incoming: ChatMessage[]
+): ChatMessage[] {
+  const byId = new Map<number, ChatMessage>()
+  for (const message of existing) byId.set(message.messageId, message)
+  for (const message of incoming) byId.set(message.messageId, message)
+  const merged = [...byId.values()].sort((a, b) => a.messageId - b.messageId)
+  return merged.length > CHAT_HISTORY_LIMIT ? merged.slice(merged.length - CHAT_HISTORY_LIMIT) : merged
+}

--- a/src/utils/__tests__/golfV2Adapter.test.ts
+++ b/src/utils/__tests__/golfV2Adapter.test.ts
@@ -191,6 +191,25 @@ describe('GolfV2NetworkAdapter', () => {
     expect(callbacks.onChatMessage).not.toHaveBeenCalled()
   })
 
+  it('gives a legacy id-less roomChat frame the old toast instead of corrupting chat state', async () => {
+    const [, ws] = await connect()
+
+    // A server that predates chat ids sends {playerId, text}: without
+    // a messageId the merge has no identity, so the adapter falls back
+    // to the notification path rather than delivering an unmergeable row.
+    ws.receive('roomChat', { playerId: 'bob', text: 'from an old server' })
+    expect(callbacks.onChatMessage).not.toHaveBeenCalled()
+    expect(callbacks.onNotification).toHaveBeenCalledWith('bob: from an old server')
+  })
+
+  it('drops id-less rows from the history replay', async () => {
+    const [, ws] = await connect()
+    const good = { messageId: 2, playerId: 'alice', text: 'kept', sentAtUnixMillis: 2 }
+
+    ws.receive('roomChatHistory', { messages: [{ playerId: 'bob', text: 'legacy row' }, good] })
+    expect(callbacks.onChatHistory).toHaveBeenCalledWith([good])
+  })
+
   it('sends chat as the exact wire command', async () => {
     const [adapter, ws] = await connect()
     adapter.sendChat('hello room')

--- a/src/utils/__tests__/golfV2Adapter.test.ts
+++ b/src/utils/__tests__/golfV2Adapter.test.ts
@@ -191,25 +191,6 @@ describe('GolfV2NetworkAdapter', () => {
     expect(callbacks.onChatMessage).not.toHaveBeenCalled()
   })
 
-  it('gives a legacy id-less roomChat frame the old toast instead of corrupting chat state', async () => {
-    const [, ws] = await connect()
-
-    // A server that predates chat ids sends {playerId, text}: without
-    // a messageId the merge has no identity, so the adapter falls back
-    // to the notification path rather than delivering an unmergeable row.
-    ws.receive('roomChat', { playerId: 'bob', text: 'from an old server' })
-    expect(callbacks.onChatMessage).not.toHaveBeenCalled()
-    expect(callbacks.onNotification).toHaveBeenCalledWith('bob: from an old server')
-  })
-
-  it('drops id-less rows from the history replay', async () => {
-    const [, ws] = await connect()
-    const good = { messageId: 2, playerId: 'alice', text: 'kept', sentAtUnixMillis: 2 }
-
-    ws.receive('roomChatHistory', { messages: [{ playerId: 'bob', text: 'legacy row' }, good] })
-    expect(callbacks.onChatHistory).toHaveBeenCalledWith([good])
-  })
-
   it('sends chat as the exact wire command', async () => {
     const [adapter, ws] = await connect()
     adapter.sendChat('hello room')

--- a/src/utils/__tests__/golfV2Adapter.test.ts
+++ b/src/utils/__tests__/golfV2Adapter.test.ts
@@ -99,7 +99,9 @@ describe('GolfV2NetworkAdapter', () => {
       onGameEnded: vi.fn(),
       onNewGameStarted: vi.fn(),
       onReconnecting: vi.fn(),
-      onGameError: vi.fn()
+      onGameError: vi.fn(),
+      onChatMessage: vi.fn(),
+      onChatHistory: vi.fn()
     }
   })
 
@@ -164,6 +166,35 @@ describe('GolfV2NetworkAdapter', () => {
     ws.receive('roomLeft', { roomId: 'ROOM01' })
     ws.receive('roomState', room)
     expect(callbacks.onRoomJoined).toHaveBeenCalledTimes(2)
+  })
+
+  it('delivers chat as typed state, never as a toast', async () => {
+    const [, ws] = await connect()
+    const message = { messageId: 7, playerId: 'bob', text: 'nice draw', sentAtUnixMillis: 1700000000000 }
+
+    ws.receive('roomChat', message)
+    expect(callbacks.onChatMessage).toHaveBeenCalledWith(message)
+    // The old path reduced chat to a transient notification; a durable
+    // message must never ride that channel again.
+    expect(callbacks.onNotification).not.toHaveBeenCalled()
+  })
+
+  it('delivers the history replay as one ordered batch', async () => {
+    const [, ws] = await connect()
+    const messages = [
+      { messageId: 1, playerId: 'alice', text: 'first', sentAtUnixMillis: 1 },
+      { messageId: 2, playerId: 'bob', text: 'second', sentAtUnixMillis: 2 }
+    ]
+
+    ws.receive('roomChatHistory', { messages })
+    expect(callbacks.onChatHistory).toHaveBeenCalledWith(messages)
+    expect(callbacks.onChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('sends chat as the exact wire command', async () => {
+    const [adapter, ws] = await connect()
+    adapter.sendChat('hello room')
+    expect(ws.lastSent()).toEqual({ event: 'chat', payload: { text: 'hello room' } })
   })
 
   it('translates game views into the v1 shape', async () => {

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -24,6 +24,11 @@
 import type { Card, GameState as GolfGameState, Player, Room, FinalScore } from '@/types/golf'
 import type { GolfAdapterCallbacks, GolfGameAdapter } from '@/types/golfAdapter'
 import type { ChatMessage } from '@/types/golfChat'
+import { isChatMessage } from '@/types/golfChat'
+
+// A server that predates chat ids (MoonBase#1226) sends {playerId, text}
+// only; isChatMessage is the runtime discrimination between the shapes.
+type V2ChatPayload = ChatMessage | { playerId: string; text: string; messageId?: undefined }
 import {
   JOINED_ROOM,
   JOINED_GAME,
@@ -123,8 +128,8 @@ type V2Frame =
   | { event: 'sessionReady'; payload: V2SessionReady }
   | { event: 'roomState'; payload: V2RoomState }
   | { event: 'roomLeft'; payload: { roomId: string } }
-  | { event: 'roomChat'; payload: ChatMessage }
-  | { event: 'roomChatHistory'; payload: { messages: ChatMessage[] } }
+  | { event: 'roomChat'; payload: V2ChatPayload }
+  | { event: 'roomChatHistory'; payload: { messages: V2ChatPayload[] } }
   | { event: 'commandRejected'; payload: { reason: string } }
   | { event: 'golf'; payload: { update: V2GolfUpdate } }
 
@@ -396,20 +401,17 @@ export class GolfV2NetworkAdapter implements GolfGameAdapter {
       case 'roomChat':
         // Typed chat state, not a toast (MoonBase#1226): the UI owns
         // presentation, and a transient notification would drop the
-        // message the server just committed durably. A server that
-        // predates chat ids (the old {playerId, text} shape) can't be
-        // merged by messageId — give those the legacy toast instead of
-        // corrupting chat state with undefined ids.
-        if (typeof frame.payload.messageId === 'number') {
+        // message the server just committed durably. An id-less legacy
+        // frame can't be merged — it gets the old toast instead of
+        // corrupting chat state.
+        if (isChatMessage(frame.payload)) {
           this.callbacks.onChatMessage?.(frame.payload)
         } else {
           this.callbacks.onNotification?.(`${frame.payload.playerId}: ${frame.payload.text}`)
         }
         return
       case 'roomChatHistory':
-        this.callbacks.onChatHistory?.(
-          frame.payload.messages.filter(m => typeof m.messageId === 'number')
-        )
+        this.callbacks.onChatHistory?.(frame.payload.messages.filter(isChatMessage))
         return
       case 'commandRejected':
         this.callbacks.onGameError?.(frame.payload.reason)

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -396,11 +396,20 @@ export class GolfV2NetworkAdapter implements GolfGameAdapter {
       case 'roomChat':
         // Typed chat state, not a toast (MoonBase#1226): the UI owns
         // presentation, and a transient notification would drop the
-        // message the server just committed durably.
-        this.callbacks.onChatMessage?.(frame.payload)
+        // message the server just committed durably. A server that
+        // predates chat ids (the old {playerId, text} shape) can't be
+        // merged by messageId — give those the legacy toast instead of
+        // corrupting chat state with undefined ids.
+        if (typeof frame.payload.messageId === 'number') {
+          this.callbacks.onChatMessage?.(frame.payload)
+        } else {
+          this.callbacks.onNotification?.(`${frame.payload.playerId}: ${frame.payload.text}`)
+        }
         return
       case 'roomChatHistory':
-        this.callbacks.onChatHistory?.(frame.payload.messages)
+        this.callbacks.onChatHistory?.(
+          frame.payload.messages.filter(m => typeof m.messageId === 'number')
+        )
         return
       case 'commandRejected':
         this.callbacks.onGameError?.(frame.payload.reason)

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -23,6 +23,7 @@
 
 import type { Card, GameState as GolfGameState, Player, Room, FinalScore } from '@/types/golf'
 import type { GolfAdapterCallbacks, GolfGameAdapter } from '@/types/golfAdapter'
+import type { ChatMessage } from '@/types/golfChat'
 import {
   JOINED_ROOM,
   JOINED_GAME,
@@ -122,7 +123,8 @@ type V2Frame =
   | { event: 'sessionReady'; payload: V2SessionReady }
   | { event: 'roomState'; payload: V2RoomState }
   | { event: 'roomLeft'; payload: { roomId: string } }
-  | { event: 'roomChat'; payload: { playerId: string; text: string } }
+  | { event: 'roomChat'; payload: ChatMessage }
+  | { event: 'roomChatHistory'; payload: { messages: ChatMessage[] } }
   | { event: 'commandRejected'; payload: { reason: string } }
   | { event: 'golf'; payload: { update: V2GolfUpdate } }
 
@@ -392,7 +394,13 @@ export class GolfV2NetworkAdapter implements GolfGameAdapter {
         this._roomState = null
         return
       case 'roomChat':
-        this.callbacks.onNotification?.(`${frame.payload.playerId}: ${frame.payload.text}`)
+        // Typed chat state, not a toast (MoonBase#1226): the UI owns
+        // presentation, and a transient notification would drop the
+        // message the server just committed durably.
+        this.callbacks.onChatMessage?.(frame.payload)
+        return
+      case 'roomChatHistory':
+        this.callbacks.onChatHistory?.(frame.payload.messages)
         return
       case 'commandRejected':
         this.callbacks.onGameError?.(frame.payload.reason)
@@ -579,6 +587,10 @@ export class GolfV2NetworkAdapter implements GolfGameAdapter {
 
   hideCards(): void {
     this.sendMove('hideCards')
+  }
+
+  sendChat(text: string): void {
+    this.sendEvent('chat', { text })
   }
 
   isMyTurn(): boolean {

--- a/src/utils/golfV2Adapter.ts
+++ b/src/utils/golfV2Adapter.ts
@@ -24,11 +24,6 @@
 import type { Card, GameState as GolfGameState, Player, Room, FinalScore } from '@/types/golf'
 import type { GolfAdapterCallbacks, GolfGameAdapter } from '@/types/golfAdapter'
 import type { ChatMessage } from '@/types/golfChat'
-import { isChatMessage } from '@/types/golfChat'
-
-// A server that predates chat ids (MoonBase#1226) sends {playerId, text}
-// only; isChatMessage is the runtime discrimination between the shapes.
-type V2ChatPayload = ChatMessage | { playerId: string; text: string; messageId?: undefined }
 import {
   JOINED_ROOM,
   JOINED_GAME,
@@ -128,8 +123,8 @@ type V2Frame =
   | { event: 'sessionReady'; payload: V2SessionReady }
   | { event: 'roomState'; payload: V2RoomState }
   | { event: 'roomLeft'; payload: { roomId: string } }
-  | { event: 'roomChat'; payload: V2ChatPayload }
-  | { event: 'roomChatHistory'; payload: { messages: V2ChatPayload[] } }
+  | { event: 'roomChat'; payload: ChatMessage }
+  | { event: 'roomChatHistory'; payload: { messages: ChatMessage[] } }
   | { event: 'commandRejected'; payload: { reason: string } }
   | { event: 'golf'; payload: { update: V2GolfUpdate } }
 
@@ -401,17 +396,11 @@ export class GolfV2NetworkAdapter implements GolfGameAdapter {
       case 'roomChat':
         // Typed chat state, not a toast (MoonBase#1226): the UI owns
         // presentation, and a transient notification would drop the
-        // message the server just committed durably. An id-less legacy
-        // frame can't be merged — it gets the old toast instead of
-        // corrupting chat state.
-        if (isChatMessage(frame.payload)) {
-          this.callbacks.onChatMessage?.(frame.payload)
-        } else {
-          this.callbacks.onNotification?.(`${frame.payload.playerId}: ${frame.payload.text}`)
-        }
+        // message the server just committed durably.
+        this.callbacks.onChatMessage?.(frame.payload)
         return
       case 'roomChatHistory':
-        this.callbacks.onChatHistory?.(frame.payload.messages.filter(isChatMessage))
+        this.callbacks.onChatHistory?.(frame.payload.messages)
         return
       case 'commandRejected':
         this.callbacks.onGameError?.(frame.payload.reason)


### PR DESCRIPTION
Phase 7 of the MoonBase#1226 golf chat series: the v2 adapter previously reduced `roomChat` to a transient toast — this turns it into a real conversation surface. Five commits: the feature, the fixes from a review-panel pass (all findings adversarially confirmed before landing), a simplification/altitude/UX pass, removal of a legacy-shape guard no deployed server needs, and wire-proven capability detection.

## Wire and state

- `roomChat` now carries the full server shape (`messageId`, `playerId`, `text`, `sentAtUnixMillis`), and the new `roomChatHistory` frame replays the room's retained 100 messages on join/resume.
- Both flow into typed chat state merged by `messageId` via the shared `mergeChatMessages` in `src/types/golfChat.ts` — at-least-once delivery, history/live overlap, duplicates, and out-of-order arrival all converge to one copy in id order, and a delivery that adds nothing returns the existing array so duplicate replays cause zero re-renders. The cap (100) and byte limit (500) mirror the server.
- `useGolfGame` owns only what the wire knows: the merged view, the observed chat capability, and `chatReplayUpTo` (highest id ever delivered by replay). Room scoping: entering a different room drops the old room's chat; a resume into the same room keeps it and dedupes the replay.

## Capability gating

Chat is v2-only and **wire-proven**: `sendChat` and the chat callbacks are optional on the adapter contract (v1 declares none), and `chatAvailable` flips true only once the current room's wire actually delivers chat — the join replay (an empty one counts) or a live message — resetting on room change. A UI deployed ahead of the server, or running against a server rolled back to a pre-chat state, renders no chat surface at all instead of a composer whose sends silently vanish.

## UI

`RoomChat` renders as one stable instance across the room lobby and in-game views, so switching between them keeps the composer draft, drawer state, and scroll position. Seen/unread is component state — only the component knows whether the panel is visible and where the reader is scrolled.

- Drawer mode by default — a floating toggle with an unread badge opens a bottom sheet (slide-up under `prefers-reduced-motion: no-preference`, tap-to-close backdrop, `dvh`-sized so the composer stays reachable when the mobile keyboard resizes the viewport, safe-area insets for the iOS home indicator). Unread accumulates only while the panel is hidden; opening marks messages seen and lands at the newest message.
- Viewports ≥1880px dock it as a sidebar — the width where the 21rem panel footprint fits beside the 1200px content column on both sides. The component owns the breakpoint via `matchMedia` and stamps a `.docked` class, so the CSS has no media query to drift out of sync.
- Auto-scroll follows only readers already at the bottom; everyone else gets a new-messages jump button instead of having scrollback yanked away, and scrollback doesn't chain into the page behind the sheet.
- Keyboard/AT: opening focuses the composer, Escape and the close button return focus to the toggle, the open sheet is a `role="dialog"`, and the polite live region sits outside the panel so a closed drawer still announces. Only live messages are announced — never the history replay (guarded by the replay watermark, in the real join order where history lands after mount) — and a repeat of identical text is still a DOM mutation (announcement span keyed by id).
- The composer counts bytes the way the server does (UTF-8, 500 max), keeps over-limit drafts unsent and editable, sends on Enter with Shift+Enter for newlines, and disables while disconnected.
- Message text renders exclusively as literal React text nodes — no HTML, no linkification.

## Testing

- 4 new test files cover the merge rule (including no-op identity), hook state (dedup, room scoping, replay watermark, wire-proven capability, send path), the component (literal rendering, composer rules, unread driven the integrated way — messages in, badge out — announcements, focus/Escape), and the adapter's chat frames.
- `tsc --noEmit`, eslint (zero-warning budget), the full vitest suite (381 tests / 31 files), and the production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKnUGAsdCmJW5b3RquYZ7u