### PR TITLE
home: fix blank band under the Julia canvas on mobile Safari

### DIFF
--- a/src/core/pages/HomePage.module.css
+++ b/src/core/pages/HomePage.module.css
@@ -1,5 +1,6 @@
 .homePage {
   height: 100vh;
+  height: 100dvh;
   width: 100vw;
   position: relative;
   overflow: hidden;

--- a/src/core/pages/NotFoundPage.module.css
+++ b/src/core/pages/NotFoundPage.module.css
@@ -1,6 +1,7 @@
 .notFoundPage {
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/hooks/useWebGL.ts
+++ b/src/hooks/useWebGL.ts
@@ -111,7 +111,10 @@ const fragmentShaderSource = `#version 300 es
       float brightness = 0.75 + t * 0.2;
 
       vec3 color = hsv2rgb(vec3(hue, saturation, brightness));
-      fragColor = vec4(color, 0.8);
+      // Previously vec4(color, 0.8) over a white page background, which the
+      // browser composites premultiplied: color + 0.2 * white. Bake that in
+      // and render opaque so the page background can be non-white.
+      fragColor = vec4(color + 0.2, 1.0);
     }
   }
 `
@@ -210,15 +213,35 @@ export const useWebGL = () => {
 
     document.addEventListener('mousemove', handleMouseMove)
 
-    // Resize canvas
+    // Size the drawing buffer to the element's on-screen size. The element is
+    // viewport-sized via CSS, and mobile viewports resize as browser chrome
+    // collapses/expands, so track the element rather than window.inner*.
     const resizeCanvas = () => {
-      canvas.width = window.innerWidth
-      canvas.height = window.innerHeight
-      gl.viewport(0, 0, canvas.width, canvas.height)
+      const width = canvas.clientWidth || window.innerWidth
+      const height = canvas.clientHeight || window.innerHeight
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width
+        canvas.height = height
+        gl.viewport(0, 0, width, height)
+      }
     }
 
     window.addEventListener('resize', resizeCanvas)
+    const resizeObserver = new ResizeObserver(resizeCanvas)
+    resizeObserver.observe(canvas)
     resizeCanvas()
+
+    // Keep the page background in sync with the canvas's bottom-edge color,
+    // so any viewport area the canvas doesn't cover (mobile browser chrome
+    // collapsing/expanding, overscroll) blends in instead of flashing white.
+    let lastBackgroundSync = -Infinity
+    const syncBackground = (time: number) => {
+      if (time - lastBackgroundSync < 1000) return
+      lastBackgroundSync = time
+      const pixel = new Uint8Array(4)
+      gl.readPixels(Math.floor(canvas.width / 2), 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel)
+      document.documentElement.style.backgroundColor = `rgb(${pixel[0]}, ${pixel[1]}, ${pixel[2]})`
+    }
 
     // Animation loop
     let animationId: number
@@ -231,6 +254,7 @@ export const useWebGL = () => {
       gl.uniform1f(timeLocation, time * 0.001)
 
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)
+      syncBackground(time)
 
       animationId = requestAnimationFrame(render)
     }
@@ -241,6 +265,8 @@ export const useWebGL = () => {
     return () => {
       document.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('resize', resizeCanvas)
+      resizeObserver.disconnect()
+      document.documentElement.style.removeProperty('background-color')
       if (animationId) {
         cancelAnimationFrame(animationId)
       }

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,11 @@ body {
 }
 
 #root {
+  /* dvh tracks the visible viewport on mobile, where 100vh is the
+     largest viewport (browser chrome collapsed) and can leave a blank
+     band at the bottom. vh first as fallback for older browsers. */
   height: 100vh;
+  height: 100dvh;
   width: 100vw;
   position: relative;
 }

--- a/src/shared/components/JuliaSetBackground.module.css
+++ b/src/shared/components/JuliaSetBackground.module.css
@@ -1,9 +1,20 @@
+/* On pages showing the Julia canvas, paint the document background in the
+   fractal's base tone. iOS Safari can expose area beyond the canvas
+   (collapsing browser chrome, overscroll, viewport offsets after gestures),
+   and the default white background read as a big blank band. */
+:global(html:has(#julia-canvas)) {
+  background-color: #e39583;
+}
+
 .juliaCanvas {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  inset: 0;
+  /* Percentages resolve against the viewport (the fixed-position containing
+     block), which tracks the visible area on iOS while the browser chrome
+     collapses/expands — unlike 100vh, which can fall short and leave a
+     blank band at the bottom. */
+  width: 100%;
+  height: 100%;
   z-index: -1;
   pointer-events: none;
 }


### PR DESCRIPTION
The homepage sized itself and its fixed background canvas with 100vh,
which on iOS Safari is the largest viewport (browser chrome collapsed).
Whenever the visible viewport disagreed - expanded chrome, overscroll,
viewport offsets after scroll gestures - Safari exposed area the page
never painted, showing the default white background as a big blank band
below the fractal.

- Size the page containers with 100dvh (100vh fallback) so the document
  tracks the visible viewport instead of the largest one.
- Pin the canvas with inset + 100% width/height so its bottom edge stays
  glued to the visible viewport bottom through chrome transitions.
- Paint the document background in the fractal's base tone on pages with
  the canvas, and keep it in sync with the rendered bottom-edge color
  each second, so any transiently exposed area blends in seamlessly.
- Render the escape region opaque, baking in the white blend the old
  alpha-0.8 output produced, so the fractal looks identical over the new
  non-white background (verified pixel colors match within 1/255).
- Track the canvas element size with a ResizeObserver instead of one-shot
  window.inner* reads so the drawing buffer follows viewport resizes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QNr5YkHC5dxjYPLvSjVUMC