### PR TITLE
golf: handle chat rate-limit refusals in the composer

### DIFF
--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -85,6 +85,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     chatMessages,
     chatAvailable,
     chatReplayUpTo,
+    chatRejection,
     sendChat,
     isConnected
   } = useGolfGame({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConnectionChange, permalinkParams })
@@ -157,6 +158,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
       playerId={playerId}
       connected={isConnected}
       replayUpTo={chatReplayUpTo}
+      rejection={chatRejection}
       onSend={sendChat}
     />
   ) : null

--- a/src/apps/golf/components/RoomChat.module.css
+++ b/src/apps/golf/components/RoomChat.module.css
@@ -158,6 +158,12 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.cooldownHint {
+  font-size: 0.6875rem;
+  color: #ffd27f;
+  text-align: right;
+}
+
 .overLimit {
   color: #ff8080;
   font-weight: 600;

--- a/src/apps/golf/components/RoomChat.tsx
+++ b/src/apps/golf/components/RoomChat.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styles from './RoomChat.module.css'
-import type { ChatMessage } from '@/types/golfChat'
-import { CHAT_TEXT_BYTE_LIMIT, chatTextBytes } from '@/types/golfChat'
+import type { ChatMessage, ChatSendBudget } from '@/types/golfChat'
+import {
+  CHAT_SLOW_DOWN_REASON,
+  CHAT_TEXT_BYTE_LIMIT,
+  chatCooldownMs,
+  chatTextBytes,
+  drainChatBudget,
+  newChatSendBudget,
+  spendChatToken
+} from '@/types/golfChat'
 
 // Room chat (MoonBase#1226): one stable instance for both the room
 // lobby and in-game views. Wide viewports dock it as a side panel;
@@ -26,6 +34,9 @@ interface RoomChatProps {
   // screen readers — only ids above both this and the mount watermark
   // are genuinely live.
   replayUpTo: number
+  // The newest command rejection, sequence-numbered by the hook. The
+  // composer reacts once per seq and only to the server's "slow down".
+  rejection: { seq: number; reason: string } | null
   onSend: (text: string) => void
 }
 
@@ -40,9 +51,15 @@ const FOLLOW_THRESHOLD_PX = 48
 // .docked class this component stamps from this one query.
 const DOCKED_QUERY = '(min-width: 1880px)'
 
+// The wire doesn't correlate rejections to commands (MoonBase#1240), so
+// restoring a refused draft is a heuristic: a "slow down" this soon
+// after our own send, with the composer still empty, is that send being
+// refused. The pacing mirror makes this a rare path.
+const REJECTION_RESTORE_WINDOW_MS = 5000
+
 const timeFormat = new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
 
-const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomChatProps) => {
+const RoomChat = ({ messages, playerId, connected, replayUpTo, rejection, onSend }: RoomChatProps) => {
   const [draft, setDraft] = useState('')
   // Drawer-mode only: whether the bottom sheet is open. The docked
   // panel ignores it — the .docked rules keep the panel visible.
@@ -52,6 +69,13 @@ const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomCha
     () => typeof window.matchMedia === 'function' && window.matchMedia(DOCKED_QUERY).matches
   )
   const [lastSeenId, setLastSeenId] = useState(0)
+  // The client-side mirror of the server's chat budget (burst 3, refill
+  // 1/s): pacing UX so honest users rarely earn a real refusal. The
+  // server stays authoritative.
+  const [budget, setBudget] = useState<ChatSendBudget>(() => newChatSendBudget(Date.now()))
+  const [cooldownUntil, setCooldownUntil] = useState<number | null>(null)
+  const [lastSent, setLastSent] = useState<{ text: string; atMs: number } | null>(null)
+  const [refused, setRefused] = useState(false)
   const listRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const toggleRef = useRef<HTMLButtonElement | null>(null)
@@ -80,6 +104,26 @@ const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomCha
           ? null
           : announced.entry
     setAnnounced({ upTo: latestId, entry })
+  }
+
+  // Server refusals, adjusted in render the same way. A "slow down"
+  // inside the restore window is our send being refused: put the text
+  // back in the composer instead of losing it, drain the mirror (the
+  // server knows the real budget — ours drifted), and say so in-panel.
+  // Unrelated rejection reasons restore nothing.
+  const [handledRejectionSeq, setHandledRejectionSeq] = useState(rejection?.seq ?? 0)
+  if (rejection && rejection.seq !== handledRejectionSeq) {
+    setHandledRejectionSeq(rejection.seq)
+    if (rejection.reason === CHAT_SLOW_DOWN_REASON) {
+      const now = Date.now()
+      if (lastSent && now - lastSent.atMs <= REJECTION_RESTORE_WINDOW_MS) {
+        if (draft === '') setDraft(lastSent.text)
+        setRefused(true)
+        const drained = drainChatBudget(now)
+        setBudget(drained)
+        setCooldownUntil(now + chatCooldownMs(drained, now))
+      }
+    }
   }
 
   useEffect(() => {
@@ -133,13 +177,39 @@ const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomCha
   const draftBytes = chatTextBytes(trimmedDraft)
   const overLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT
   const nearLimit = draftBytes > CHAT_TEXT_BYTE_LIMIT - 100
+  const coolingDown = cooldownUntil !== null
 
   const send = useCallback(() => {
     if (!trimmedDraft || !connected || overLimit) return
+    const now = Date.now()
+    // Spend from the mirror before shipping; an empty bucket keeps the
+    // draft in place and starts the cooldown instead of earning a
+    // server refusal. Refill accrues either way.
+    const spent = spendChatToken(budget, now)
+    setBudget(spent.budget)
+    const wait = chatCooldownMs(spent.budget, now)
+    if (!spent.ok) {
+      setCooldownUntil(now + wait)
+      return
+    }
     onSend(trimmedDraft)
+    setLastSent({ text: trimmedDraft, atMs: now })
     setDraft('')
+    setRefused(false)
     followingRef.current = true
-  }, [trimmedDraft, connected, overLimit, onSend])
+    if (wait > 0) setCooldownUntil(now + wait)
+  }, [trimmedDraft, connected, overLimit, budget, onSend])
+
+  // Re-enable Send as the mirror refills: the timeout is the clock
+  // reporting back in.
+  useEffect(() => {
+    if (cooldownUntil === null) return
+    const timer = setTimeout(() => {
+      setCooldownUntil(null)
+      setRefused(false)
+    }, Math.max(0, cooldownUntil - Date.now()))
+    return () => clearTimeout(timer)
+  }, [cooldownUntil])
 
   const onComposerKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -264,6 +334,14 @@ const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomCha
             aria-label="Chat message"
           />
           <div className={styles.composerSide}>
+            {/* role="status" is a polite live region, so the cooldown
+              * and refusal reach screen readers without touching the
+              * message announcement region. */}
+            {(refused || coolingDown) && (
+              <span className={styles.cooldownHint} role="status">
+                {refused ? 'not sent — hold on a moment…' : 'hold on a moment…'}
+              </span>
+            )}
             {(nearLimit || overLimit) && (
               <span className={`${styles.byteCount} ${overLimit ? styles.overLimit : ''}`}>
                 {draftBytes}/{CHAT_TEXT_BYTE_LIMIT}
@@ -273,7 +351,8 @@ const RoomChat = ({ messages, playerId, connected, replayUpTo, onSend }: RoomCha
               type="button"
               className={styles.sendButton}
               onClick={send}
-              disabled={!connected || trimmedDraft.length === 0 || overLimit}
+              disabled={!connected || trimmedDraft.length === 0 || overLimit || coolingDown}
+              title={coolingDown ? 'Chat is rate limited — waiting a moment' : undefined}
             >
               Send
             </button>

--- a/src/apps/golf/components/__tests__/RoomChat.test.tsx
+++ b/src/apps/golf/components/__tests__/RoomChat.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import RoomChat from '../RoomChat'
 import type { ChatMessage } from '@/types/golfChat'
@@ -19,6 +19,7 @@ const baseProps = {
   playerId: 'alice',
   connected: true,
   replayUpTo: 0,
+  rejection: null,
   onSend: vi.fn()
 }
 
@@ -210,5 +211,83 @@ describe('RoomChat', () => {
 
     fireEvent.keyDown(input, { key: 'Escape' })
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Open chat' }))
+  })
+
+  it('paces bursts to the server budget and re-enables as tokens refill', () => {
+    vi.useFakeTimers()
+    try {
+      render(<RoomChat {...baseProps} messages={[]} />)
+      const input = screen.getByLabelText('Chat message')
+
+      for (let i = 1; i <= 3; i++) {
+        fireEvent.change(input, { target: { value: `m${i}` } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+      }
+      expect(baseProps.onSend).toHaveBeenCalledTimes(3)
+
+      // Bucket empty: the fourth stays in the composer, Send disables,
+      // and the polite status region explains why.
+      fireEvent.change(input, { target: { value: 'm4' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(baseProps.onSend).toHaveBeenCalledTimes(3)
+      expect((input as HTMLTextAreaElement).value).toBe('m4')
+      expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+      expect(screen.getByRole('status').textContent).toContain('hold on')
+
+      // One refill later the composer works again.
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled()
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(baseProps.onSend).toHaveBeenCalledTimes(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('restores the draft when the server refuses a recent send with slow down', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+    fireEvent.change(input, { target: { value: 'good luck' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(baseProps.onSend).toHaveBeenCalledWith('good luck')
+    expect((input as HTMLTextAreaElement).value).toBe('')
+
+    rerender(
+      <RoomChat {...baseProps} messages={[]} rejection={{ seq: 1, reason: 'slow down' }} />
+    )
+    expect((input as HTMLTextAreaElement).value).toBe('good luck')
+    expect(screen.getByRole('status').textContent).toContain('not sent')
+    // The server said the budget is empty — the mirror resyncs, so Send
+    // waits for the refill instead of earning another refusal.
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+  })
+
+  it('does not clobber a retyped draft when the refusal lands', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+    fireEvent.change(input, { target: { value: 'first' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.change(input, { target: { value: 'second draft' } })
+
+    rerender(
+      <RoomChat {...baseProps} messages={[]} rejection={{ seq: 1, reason: 'slow down' }} />
+    )
+    expect((input as HTMLTextAreaElement).value).toBe('second draft')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('restores nothing for unrelated rejections', () => {
+    const { rerender } = render(<RoomChat {...baseProps} messages={[]} />)
+    const input = screen.getByLabelText('Chat message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    rerender(
+      <RoomChat {...baseProps} messages={[]} rejection={{ seq: 1, reason: 'not in a room' }} />
+    )
+    expect((input as HTMLTextAreaElement).value).toBe('')
+    expect(screen.queryByRole('status')).toBeNull()
   })
 })

--- a/src/hooks/__tests__/useGolfGame.chat.test.tsx
+++ b/src/hooks/__tests__/useGolfGame.chat.test.tsx
@@ -38,6 +38,7 @@ const mockNetworkAdapter = {
     onRoomJoined?: (playerId: string, roomState: Room) => void
     onChatMessage?: (message: ChatMessage) => void
     onChatHistory?: (messages: ChatMessage[]) => void
+    onGameError?: (message: string) => void
   } | null
 }
 
@@ -194,6 +195,28 @@ describe('useGolfGame - room chat', () => {
       mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM02'))
     })
     expect(result.current.chatReplayUpTo).toBe(0)
+  })
+
+  it('surfaces command rejections with a sequence, cleared with the room', () => {
+    const { result } = renderHook(() => useGolfGame(), { wrapper })
+    expect(result.current.chatRejection).toBeNull()
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onGameError?.('slow down')
+    })
+    expect(result.current.chatRejection).toEqual({ seq: 1, reason: 'slow down' })
+
+    // The same reason again is a new refusal: the seq moves so a
+    // consumer reacting per-seq sees it.
+    act(() => {
+      mockNetworkAdapter._callbacks?.onGameError?.('slow down')
+    })
+    expect(result.current.chatRejection).toEqual({ seq: 2, reason: 'slow down' })
+
+    act(() => {
+      mockNetworkAdapter._callbacks?.onRoomJoined?.('alice', makeRoom('ROOM01'))
+    })
+    expect(result.current.chatRejection).toBeNull()
   })
 
   it('trims before sending and refuses whitespace-only drafts', () => {

--- a/src/hooks/useGolfGame.ts
+++ b/src/hooks/useGolfGame.ts
@@ -48,6 +48,11 @@ interface UseGolfGameReturn {
   // Highest messageId ever delivered via a history replay: consumers
   // that announce live messages use it to keep replays silent.
   chatReplayUpTo: number
+  // The newest command rejection off the wire, sequence-numbered so a
+  // consumer reacts exactly once per refusal even when reasons repeat.
+  // Reasons are uninterpreted here — the chat composer picks out the
+  // server's "slow down" (MoonBase#1241) for its draft restore.
+  chatRejection: { seq: number; reason: string } | null
   sendChat: (text: string) => void
   
   // New game notifications
@@ -132,6 +137,7 @@ export const useGolfGame = ({
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
   const [chatReplayUpTo, setChatReplayUpTo] = useState(0)
   const [chatAvailable, setChatAvailable] = useState(false)
+  const [chatRejection, setChatRejection] = useState<{ seq: number; reason: string } | null>(null)
   // The room the chat state belongs to: entering a different room drops
   // the old room's messages before its history lands.
   const chatRoomRef = useRef<string | null>(null)
@@ -139,6 +145,7 @@ export const useGolfGame = ({
     chatRoomRef.current = roomId
     setChatMessages([])
     setChatReplayUpTo(0)
+    setChatRejection(null)
     // Capability is re-proven per room: the next replay or live message
     // flips it back.
     setChatAvailable(false)
@@ -594,6 +601,9 @@ export const useGolfGame = ({
         setChatReplayUpTo(prev => messages.reduce((max, m) => Math.max(max, m.messageId), prev))
       },
       onGameError: (errorMessage) => {
+        // Every rejection also flows to chat state — the composer
+        // reacts once per seq, and only to reasons it recognizes.
+        setChatRejection(prev => ({ seq: (prev?.seq ?? 0) + 1, reason: errorMessage }))
         if (permalinkJoinAttempt.isAttempting &&
             (errorMessage.includes('not found') || errorMessage.includes('does not exist'))) {
           if (permalinkTimeoutRef.current) {
@@ -893,6 +903,7 @@ export const useGolfGame = ({
     chatMessages,
     chatAvailable,
     chatReplayUpTo,
+    chatRejection,
     sendChat,
 
     // New game notifications

--- a/src/types/__tests__/golfChat.test.ts
+++ b/src/types/__tests__/golfChat.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import {
+  CHAT_BURST,
   CHAT_HISTORY_LIMIT,
   CHAT_TEXT_BYTE_LIMIT,
+  chatCooldownMs,
   chatTextBytes,
+  drainChatBudget,
   mergeChatMessages,
+  newChatSendBudget,
+  spendChatToken,
   type ChatMessage
 } from '../golfChat'
 
@@ -75,5 +80,54 @@ describe('chatTextBytes', () => {
     expect(chatTextBytes('é')).toBe(2)
     expect(chatTextBytes('🎉')).toBe(4)
     expect(CHAT_TEXT_BYTE_LIMIT).toBe(500)
+  })
+})
+
+// The pacing mirror of the server's chat budget (MoonBase#1240/#1241):
+// pure functions of (state, clock), so tests fabricate time the same
+// way the server's rate_limiter_test does.
+describe('chat send budget', () => {
+  const t0 = 1_700_000_000_000
+
+  it('allows the full burst immediately, then refuses', () => {
+    let budget = newChatSendBudget(t0)
+    for (let i = 0; i < CHAT_BURST; i++) {
+      const spent = spendChatToken(budget, t0)
+      expect(spent.ok).toBe(true)
+      budget = spent.budget
+    }
+    expect(spendChatToken(budget, t0).ok).toBe(false)
+  })
+
+  it('refills one token per second and caps at the burst', () => {
+    let budget = newChatSendBudget(t0)
+    for (let i = 0; i < CHAT_BURST; i++) budget = spendChatToken(budget, t0).budget
+
+    // 999ms is not a whole token yet.
+    const early = spendChatToken(budget, t0 + 999)
+    expect(early.ok).toBe(false)
+
+    // The refill accrued during the refused spend: 1ms later the whole
+    // token exists — and exactly one of it.
+    const one = spendChatToken(early.budget, t0 + 1000)
+    expect(one.ok).toBe(true)
+    expect(spendChatToken(one.budget, t0 + 1000).ok).toBe(false)
+
+    // A long idle stretch refills to the cap, never beyond it.
+    let idle = one.budget
+    for (let i = 0; i < CHAT_BURST; i++) {
+      const spent = spendChatToken(idle, t0 + 60_000)
+      expect(spent.ok).toBe(true)
+      idle = spent.budget
+    }
+    expect(spendChatToken(idle, t0 + 60_000).ok).toBe(false)
+  })
+
+  it('reports the wait until the next whole token', () => {
+    const drained = drainChatBudget(t0)
+    expect(chatCooldownMs(drained, t0)).toBe(1000)
+    expect(chatCooldownMs(drained, t0 + 400)).toBe(600)
+    expect(chatCooldownMs(drained, t0 + 1000)).toBe(0)
+    expect(chatCooldownMs(newChatSendBudget(t0), t0)).toBe(0)
   })
 })

--- a/src/types/golfChat.ts
+++ b/src/types/golfChat.ts
@@ -23,6 +23,61 @@ const encoder = new TextEncoder()
 
 export const chatTextBytes = (text: string): number => encoder.encode(text).length
 
+// Mirrors the server's per-session chat budget (MoonBase#1240/#1241):
+// burst 3, refill 1/s per connection. The mirror is pacing UX only —
+// the server stays authoritative, so consumers must tolerate drift and
+// treat a refusal as the truth (drainChatBudget resyncs from empty).
+export const CHAT_BURST = 3
+export const CHAT_REFILL_PER_SEC = 1
+
+// The server's commandRejected reason for an over-budget chat message.
+export const CHAT_SLOW_DOWN_REASON = 'slow down'
+
+// A token bucket with explicit time: callers pass nowMs, so behavior is
+// a pure function of (state, clock) and tests fabricate time the same
+// way the server's rate_limiter_test does.
+export interface ChatSendBudget {
+  // Fractional tokens as of asOfMs, capped at CHAT_BURST.
+  tokens: number
+  asOfMs: number
+}
+
+export const newChatSendBudget = (nowMs: number): ChatSendBudget => ({
+  tokens: CHAT_BURST,
+  asOfMs: nowMs
+})
+
+// The server refused: it knows the real budget, the mirror drifted.
+// Restart empty and let refill catch up.
+export const drainChatBudget = (nowMs: number): ChatSendBudget => ({
+  tokens: 0,
+  asOfMs: nowMs
+})
+
+const refilled = (budget: ChatSendBudget, nowMs: number): number =>
+  Math.min(
+    CHAT_BURST,
+    budget.tokens + (Math.max(0, nowMs - budget.asOfMs) / 1000) * CHAT_REFILL_PER_SEC
+  )
+
+// Spend one token if a whole one is available. Returns the advanced
+// budget either way — refill accrues even on a refused spend.
+export function spendChatToken(
+  budget: ChatSendBudget,
+  nowMs: number
+): { budget: ChatSendBudget; ok: boolean } {
+  const tokens = refilled(budget, nowMs)
+  if (tokens < 1) return { budget: { tokens, asOfMs: nowMs }, ok: false }
+  return { budget: { tokens: tokens - 1, asOfMs: nowMs }, ok: true }
+}
+
+// Milliseconds until a whole token is available; 0 when sendable now.
+export function chatCooldownMs(budget: ChatSendBudget, nowMs: number): number {
+  const tokens = refilled(budget, nowMs)
+  if (tokens >= 1) return 0
+  return Math.ceil(((1 - tokens) * 1000) / CHAT_REFILL_PER_SEC)
+}
+
 // One sorted, deduplicated view of everything seen so far, capped to the
 // newest CHAT_HISTORY_LIMIT. messageId is the only ordering key — the
 // timestamp is wall-clock and display-only. Handles every arrival shape


### PR DESCRIPTION
MoonBase#1240/#1241 put per-session stream budgets on the golf hub, and chat's is the tight one: **burst 3, refill 1/s** per connection, refused over budget with `commandRejected { reason: "slow down" }` — nothing stored, nothing echoed. The composer clears on send, so a refused message's text was simply gone. Worse than the issue describes, in fact: the hook's `onGameError` only handled permalink failures, so the refusal surfaced *nowhere* — not even the generic toast.

## Pacing mirror (primary fix — refusals should be rare)

`src/types/golfChat.ts` grows a mirror of the server budget beside `CHAT_TEXT_BYTE_LIMIT`: `CHAT_BURST`, `CHAT_REFILL_PER_SEC`, `CHAT_SLOW_DOWN_REASON`, and a pure token bucket (`newChatSendBudget` / `spendChatToken` / `chatCooldownMs` / `drainChatBudget`) that takes `nowMs` explicitly — behavior is a function of (state, clock), tested with fabricated time the same way the server's `rate_limiter_test` is.

The composer spends from the mirror before shipping. An empty bucket:
- keeps the draft in place instead of sending into a refusal,
- disables Send with a `title` explaining why,
- shows a quiet "hold on a moment…" hint in the composer,
- and re-enables via a timeout as tokens refill.

The mirror is UX, not enforcement — the server stays authoritative, and the mirror tolerates drift (below).

## Draft preservation when a refusal happens anyway

`useGolfGame` now surfaces every command rejection as sequence-numbered `chatRejection` state (cleared with the room), so the composer reacts exactly once per refusal even when reasons repeat. The wire doesn't correlate rejections to commands, so the restore is the documented heuristic from the issue: a `"slow down"` within 5s of our own send, with the composer still empty, restores the sent text — a retyped draft is never clobbered — and **drains the mirror**, resyncing it from the budget the server just proved empty. Unrelated reasons (`"not in a room"`) restore nothing.

## In-panel feedback + accessibility

The cooldown/refusal notice lives in the composer's hint area next to the byte counter — visible with the drawer open (z-50), where the global toast layer can be covered. Refusals read "not sent — hold on a moment…". The hint carries `role="status"`, a polite live region that's a sibling of the message-announcement region — the history-replay suppression rule is untouched.

## Tests

- Bucket mirror: fabricated-time units for burst, refill accrual (including during a refused spend), the cap, and cooldown math.
- Composer: burst-fast sending disables Send and shows the hint; a refill re-enables it (fake timers); the refused draft survives in the composer.
- Restore heuristic: `"slow down"` after a recent send restores and drains; a retyped draft is not clobbered; an unrelated rejection restores nothing.
- Hook: rejections sequence per refusal and clear with the room.
- Full suite 389/389; `tsc --noEmit`, eslint (zero-warning budget), and the production build all pass.

## Non-goals (per the issue)

Client-side enforcement (the server budget is the boundary), and pacing non-chat commands (burst 10, 5/s is out of reach for click-driven play).

Refs: muchq/MoonBase#1240, muchq/MoonBase#1241, muchq/MoonBase#1226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKnUGAsdCmJW5b3RquYZ7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKnUGAsdCmJW5b3RquYZ7u)_