### PR TITLE
fix(metrics): stop reading restart count as container state

### DIFF
--- a/src/apps/metrics-systems/__tests__/api.test.ts
+++ b/src/apps/metrics-systems/__tests__/api.test.ts
@@ -204,9 +204,13 @@ describe('containerState', () => {
     expect(containerState(legacy as unknown as ContainerStats)).toBe('up')
   })
 
-  it('ranks a crash loop above ordinary restart churn', () => {
+  it('does not read restart churn as a state', () => {
+    // `restarts_last_hour` is a count over a trailing hour, not a current
+    // condition: a host reboot leaves every container at 1 for the next hour,
+    // which painted the whole stack red while it was up and serving. Only the
+    // crash-loop rule pairs that count with uptime, so only it is a state.
+    expect(containerState(stats({ name: 'a', restarts_last_hour: 2 }))).toBe('up')
     expect(containerState(stats({ name: 'a', crash_looping: true, restarts_last_hour: 5 }))).toBe('crash looping')
-    expect(containerState(stats({ name: 'a', restarts_last_hour: 2 }))).toBe('restarting')
   })
 })
 

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -116,8 +116,10 @@ export function containerLabelLookup(containers: ContainerStats[]): (name: strin
   return (name: string) => byName.get(name) ?? containerDisplayName(name)
 }
 
-// Crash-looping first, then whatever else is restarting, so a failing container
-// can't sit below the fold of a long list.
+// Crash-looping first, then whatever has churned most, so a failing container
+// can't sit below the fold of a long list. Restart count orders the tail even
+// though it is no longer a state of its own: a container that restarted twice
+// is still the more interesting one to look at first.
 export function byHealthThenName(a: ContainerStats, b: ContainerStats): number {
   if (!!a.crash_looping !== !!b.crash_looping) return a.crash_looping ? -1 : 1
   const restarts = (b.restarts_last_hour ?? 0) - (a.restarts_last_hour ?? 0)
@@ -190,10 +192,18 @@ export function hasDrifted(container: ContainerStats, stack: string | null): boo
   return container.version !== stack
 }
 
-export type ContainerState = 'up' | 'restarting' | 'crash looping' | 'not reporting'
+export type ContainerState = 'up' | 'crash looping' | 'not reporting'
 
 // The health verdict, in one place so the service strip and the Containers tab
 // can't drift apart about what "up" means.
+//
+// State is liveness, never history. `restarts_last_hour` is a count over a
+// trailing window — prom_proxy derives it from changes(container_start_time_
+// seconds[1h]) — so a host reboot puts every container at 1 for the next hour.
+// Reading that as its own state painted a fully healthy stack red until the
+// window rolled off. The RESTARTS column already carries the churn; the only
+// thing that turns a restart count into a condition is pairing it with uptime,
+// and `crash_looping` is where that pairing lives.
 //
 // `not reporting` cannot collapse into `up`: a failed cAdvisor query leaves
 // zero restarts and zero uptime, which is byte-identical to a healthy
@@ -202,7 +212,7 @@ export type ContainerState = 'up' | 'restarting' | 'crash looping' | 'not report
 export function containerState(container: ContainerStats): ContainerState {
   if (container.reporting === false) return 'not reporting'
   if (container.crash_looping) return 'crash looping'
-  return (container.restarts_last_hour ?? 0) > 0 ? 'restarting' : 'up'
+  return 'up'
 }
 
 export function formatBytes(bytes: number): string {

--- a/src/apps/metrics-systems/components/ContainerHealth.tsx
+++ b/src/apps/metrics-systems/components/ContainerHealth.tsx
@@ -11,7 +11,7 @@ import { containerLabel, containerState, formatUptime, type ContainerStats, type
 //                   same thing, and fetchJson can't tell them apart, so this
 //                   renders "unknown" rather than claiming the container is gone
 //   reporting=false cAdvisor knows the container but returned no samples
-//   otherwise       real numbers, so up/restarting/crash-looping is decidable
+//   otherwise       real numbers, so up/crash-looping is decidable
 //
 // The middle case has to stay distinct from a healthy zero: a failed query
 // leaves 0 restarts and 0 uptime, which would otherwise render as "up".
@@ -22,7 +22,6 @@ import { containerLabel, containerState, formatUptime, type ContainerStats, type
 // that matters, a container that is down while every chart looks idle-healthy.
 const STATE_STYLES: Record<ContainerState, string> = {
   up: 'stateUp',
-  restarting: 'stateWarn',
   'crash looping': 'stateDown',
   'not reporting': 'stateUnknown',
 }

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -205,12 +205,6 @@
   border: 1px solid rgba(102, 255, 136, 0.35);
 }
 
-.stateWarn {
-  color: #ffcc66;
-  background: rgba(255, 204, 102, 0.1);
-  border: 1px solid rgba(255, 204, 102, 0.35);
-}
-
 .stateDown {
   color: #ff6b6b;
   background: rgba(255, 107, 107, 0.12);

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -532,7 +532,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
             The host runs more than four, and the truncated list was in
             arbitrary Prometheus order, so the one container worth looking
             at was the one most likely to be cut. Sorted so anything
-            crash-looping or restarting sorts to the front. Titled, and the
+            crash-looping or churning sorts to the front. Titled, and the
             value carries its unit — a bare percentage on an unlabeled card
             doesn't say what's being measured. */}
         {containerMetrics && containerMetrics.containers.length > 0 && (

--- a/src/apps/metrics-systems/components/__tests__/ContainersDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ContainersDashboard.test.tsx
@@ -78,18 +78,26 @@ describe('ContainersDashboard', () => {
     withContainers([
       makeContainer('aaa_healthy'),
       makeContainer('zzz_looping', { crash_looping: true, restarts_last_hour: 5, uptime_seconds: 30 }),
-      makeContainer('mmm_restarting', { restarts_last_hour: 2 }),
+      makeContainer('mmm_churn', { restarts_last_hour: 2 }),
     ])
 
     await settle()
 
     const rows = within(screen.getByTestId('containers-table')).getAllByRole('row').slice(1)
     const labels = rows.map((row) => row.getAttribute('data-testid'))
-    expect(labels).toEqual([
-      'container-row-zzz_looping',
-      'container-row-mmm_restarting',
-      'container-row-aaa_healthy',
-    ])
+    expect(labels).toEqual(['container-row-zzz_looping', 'container-row-mmm_churn', 'container-row-aaa_healthy'])
+  })
+
+  it('does not flag a container that restarted and then stayed up', async () => {
+    // Every container restarts once when the host reboots, and the count sits
+    // at 1 for the following hour. Treating that as a state marked the entire
+    // stack unhealthy while every service was answering requests.
+    withContainers([makeContainer('golf_hub', { restarts_last_hour: 1, uptime_seconds: 720 })])
+
+    await settle()
+
+    expect(screen.getByTestId('container-row-state-golf_hub').textContent).toBe('up')
+    expect(screen.getByTestId('container-row-golf_hub').className).toBe('')
   })
 
   it('shows how stale each container is, which uptime cannot answer', async () => {

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -335,7 +335,9 @@ describe('ServiceDashboard', () => {
       expect(screen.queryByText('Sessions')).toBeNull()
     })
 
-    it('reports restarts that have not yet met the crash-loop rule', async () => {
+    it('stays up on restarts that have not met the crash-loop rule', async () => {
+      // A container that restarted and then stayed up is up. The count is
+      // still worth showing — it just isn't the verdict.
       mockFetch.mockImplementation((url: string) => {
         if (url.endsWith('/container/golf_hub')) {
           return ok(containerDetail({ crash_looping: false, restarts_last_hour: 2 }))
@@ -345,7 +347,7 @@ describe('ServiceDashboard', () => {
 
       await renderAndSettle()
 
-      expect(screen.getByTestId('container-state').textContent).toBe('restarting')
+      expect(screen.getByTestId('container-state').textContent).toBe('up')
       expect(screen.getByTestId('container-restarts').textContent).toBe('2')
     })
 


### PR DESCRIPTION
The Containers tab derived state from `restarts_last_hour`, which is a count over a trailing hour (prom_proxy gets it from `changes(container_start_time_seconds[1h])`), not a current condition. A host reboot restarts everything once, so the whole stack rendered as "restarting" for the next hour while every service was up and answering requests.

State is liveness only now — up, crash looping, or not reporting. `crash_looping` already pairs the restart count with uptime, which is what makes it a condition rather than history. The restart count keeps its own column and still sorts unhealthy containers to the top, so nothing is hidden.

Tested with `npx vitest run src/apps/metrics-systems` (90 passing), plus typecheck, lint and build.