### PR TITLE
test: give jsdom tests a real storage shim, bump CI to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
 
     - name: Install dependencies

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,33 @@ import { expect, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import * as matchers from '@testing-library/jest-dom/matchers'
 
+// Node 22.4+ puts localStorage/sessionStorage on globalThis itself, and without
+// --localstorage-file the getter returns undefined. That own property shadows
+// the store jsdom installs, so `localStorage.clear()` throws on a newer Node
+// while passing on an older one — the same suite goes red purely on runtime.
+//
+// jsdom's own store is unreachable from here: under vitest's jsdom environment
+// `window` IS globalThis, so reading window.localStorage returns the same
+// undefined. Install a store instead. It is per test file, since setupFiles run
+// once per file, which also removes the cross-file leakage a shared one has.
+const memoryStorage = (): Storage => {
+  let entries = new Map<string, string>()
+  return {
+    get length() {
+      return entries.size
+    },
+    key: (i: number) => [...entries.keys()][i] ?? null,
+    getItem: (k: string) => entries.get(k) ?? null,
+    setItem: (k: string, v: string) => void entries.set(k, String(v)),
+    removeItem: (k: string) => void entries.delete(k),
+    clear: () => void (entries = new Map()),
+  }
+}
+
+for (const key of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, key, { value: memoryStorage(), configurable: true })
+}
+
 // extends Vitest's expect method with methods from react-testing-library
 expect.extend(matchers)
 


### PR DESCRIPTION
Node 22.4+ defines `localStorage` on `globalThis`, and without `--localstorage-file` the getter returns undefined. That own property shadows the store jsdom installs, so the golf v2 and permalink suites throw `Cannot read properties of undefined (reading 'clear')` on a recent Node — 34 failures that CI never saw because it pinned node 22.

Forwarding jsdom's store doesn't work: under vitest's jsdom environment `window` is `globalThis`, so `window.localStorage` reads back the same undefined. The setup file installs an in-memory Storage instead. setupFiles run once per test file, so each file gets a fresh one.

CI moves to 24 now that the suite doesn't depend on the runtime lacking web storage. 24 is the active LTS until October.

Verified on node 26 locally: 389 passing, plus typecheck, lint and build.