### PR TITLE
Count/rate toggle for counter tiles, and stop calling a 5m count "Total"

### DIFF
--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -25,10 +25,20 @@ export interface StandardMetrics {
   active_requests: number
 }
 
+// Which form counter-derived tiles are in (MoonBase#1287). The proxy takes
+// this as ?view= and echoes it back; anything else is a 400, so these two are
+// the whole vocabulary.
+export type MetricView = 'count' | 'rate'
+
 export interface CustomMetricValue {
   label: string
   value: number
   unit: string
+  // True when the tile is counter-derived and so has both a count and a rate
+  // form. Optional for the usual reason: a Pages build can land while the host
+  // still runs a prom_proxy from before MoonBase#1287. Absent means "one form",
+  // which is how every tile behaved before the flag existed.
+  toggleable?: boolean
 }
 
 export interface CustomMetricGroup {
@@ -40,7 +50,36 @@ export interface ServiceMetricsResponse {
   timestamp: string
   service: string
   standard: StandardMetrics
+  // The form the toggleable tiles came back in. Absent from a pre-MoonBase#1287
+  // proxy, which is also the signal that `requests_total` is still a lifetime
+  // total rather than a windowed count — see requestsTotalLabel.
+  view?: MetricView
   custom: CustomMetricGroup[]
+}
+
+// Whether this payload has any tile worth offering a toggle for.
+//
+// Asked of the payload rather than assumed from the service, because it is a
+// property of what the proxy sent: a host running an older prom_proxy sends no
+// `toggleable` flags at all, and a switch that changes nothing on screen is
+// worse than no switch.
+export function hasToggleableMetrics(response: ServiceMetricsResponse | null): boolean {
+  return !!response?.custom?.some((group) => group.metrics?.some((metric) => metric.toggleable))
+}
+
+// What to call the standard block's `requests_total` tile.
+//
+// MoonBase#1287 changed that field from sum(x) — cumulative since process
+// start, and so reset by every deploy — to a 5-minute increase(). The JSON key
+// could not change without breaking this UI, so the name still says "total"
+// while the number no longer is one; calling the tile "Total" would repeat the
+// same wrong label the API is stuck with.
+//
+// `view` is the tell: it is present exactly when the proxy carries that change,
+// because both landed in the same commit. An older host therefore keeps the
+// old label, which is still honest about the number it is actually sending.
+export function requestsTotalLabel(response: ServiceMetricsResponse | null): string {
+  return response?.view ? 'Req (5m)' : 'Total'
 }
 
 // Per-container stats. A service that dies during startup never serves a

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -8,10 +8,13 @@ import {
   bucketMs,
   fetchJson,
   fillWindow,
+  hasToggleableMetrics,
+  requestsTotalLabel,
   seriesWindow,
   serviceDisplayName,
   type ContainerDetail,
   type ContainerStats,
+  type MetricView,
   type SeriesWindow,
   type ServiceMetricsResponse,
   type TimeSeries,
@@ -127,6 +130,9 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const [timeseries, setTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [container, setContainer] = useState<ContainerStats | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
+  // Which form counter tiles are asked for (MoonBase#1287). Count matches the
+  // proxy's own default, so the first paint is one request rather than two.
+  const [view, setView] = useState<MetricView>('count')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
   const [lastService, setLastService] = useState(service)
   // True until the first fetch for this service settles either way. Empty
@@ -158,7 +164,11 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
       // service name server-side, so this no longer pulls the whole host
       // payload — every other container's stats — to use one row of it.
       const [scalarData, seriesData, containerData] = await Promise.all([
-        fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}`),
+        // ?view= is safe against an older proxy: Go's mux ignores query
+        // parameters nothing reads, so the request still succeeds and comes
+        // back in the only form that proxy has. The switch stays hidden in
+        // that case anyway — see hasToggleableMetrics.
+        fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}?view=${view}`),
         fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
         fetchJson<ContainerDetail>(`${METRICS_API_URL}/container/${service}`),
       ])
@@ -186,7 +196,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
       clearTimeout(start)
       clearInterval(interval)
     }
-  }, [service, timeRange, onConnectionStateChange])
+  }, [service, timeRange, view, onConnectionStateChange])
 
   const findSeries = (name: string) => timeseries?.series?.find((s) => s.metric_name === name)
   const customSeries = (timeseries?.series ?? []).filter((s) => !STANDARD_SERIES.has(s.metric_name))
@@ -216,6 +226,21 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             <option value="1d">1d</option>
             <option value="7d">7d</option>
           </select>
+          {/* Only when the payload actually has counter tiles to switch. A
+              service whose custom block is all gauges and windowed means has
+              nothing this would change, and neither does a host still running
+              a pre-MoonBase#1287 proxy. */}
+          {hasToggleableMetrics(scalar) && (
+            <select
+              value={view}
+              onChange={(e) => setView(e.target.value as MetricView)}
+              className={styles.timeRangeSelect}
+              aria-label="Counter view"
+            >
+              <option value="count">count</option>
+              <option value="rate">rate</option>
+            </select>
+          )}
           {lastUpdate && (
             <span className={styles.lastUpdate}>
               {lastUpdate.toLocaleTimeString()}
@@ -261,7 +286,9 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
                 <div className={styles.miniValue}>{(standard.active_requests || 0).toFixed(0)}</div>
               </div>
               <div className={styles.miniCard}>
-                <div className={styles.miniLabel}>Total</div>
+                {/* Not "Total" once the proxy is new enough: the field still
+                    says total, but MoonBase#1287 made it a 5-minute count. */}
+                <div className={styles.miniLabel}>{requestsTotalLabel(scalar)}</div>
                 <div className={styles.miniValue}>{formatValue(standard.requests_total || 0)}</div>
               </div>
             </div>

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -24,6 +24,7 @@ vi.mock('recharts', () => ({
 const scalarResponse = {
   timestamp: new Date().toISOString(),
   service: 'golf_hub',
+  view: 'count',
   standard: {
     requests_total: 1234,
     rate_per_sec: 1.25,
@@ -36,7 +37,28 @@ const scalarResponse = {
   },
   custom: [
     { title: 'Sessions', metrics: [{ label: 'active', value: 3, unit: 'sessions' }] },
-    { title: 'Activity', metrics: [{ label: 'commands_per_sec', value: 0.5, unit: '/s' }] },
+    { title: 'Activity', metrics: [{ label: 'commands', value: 12, unit: '', toggleable: true }] },
+  ],
+}
+
+// The same payload as the proxy answers it for ?view=rate: same tiles, same
+// labels, different numbers and units. The label carries no form suffix
+// precisely because it has to read correctly under both.
+const rateScalarResponse = {
+  ...scalarResponse,
+  view: 'rate',
+  custom: [
+    { title: 'Sessions', metrics: [{ label: 'active', value: 3, unit: 'sessions' }] },
+    { title: 'Activity', metrics: [{ label: 'commands', value: 0.04, unit: '/s', toggleable: true }] },
+  ],
+}
+
+// A host still running a pre-MoonBase#1287 proxy: no `view`, no `toggleable`.
+const legacyScalarResponse = {
+  ...scalarResponse,
+  view: undefined,
+  custom: [
+    { title: 'Sessions', metrics: [{ label: 'active', value: 3, unit: 'sessions' }] },
   ],
 }
 
@@ -78,6 +100,11 @@ const containerDetail = (overrides: Record<string, unknown> = {}) => ({
   },
 })
 
+// The scalar endpoint is fetched with ?view=, so endsWith on the whole URL no
+// longer matches it. Compare the path and read the view separately.
+const pathOf = (url: string) => url.split('?')[0]
+const viewOf = (url: string) => new URLSearchParams(url.split('?')[1] ?? '').get('view') ?? 'count'
+
 const ok = (body: unknown) => Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
 const notFound = () => Promise.resolve({ ok: false, text: () => Promise.resolve('') })
 
@@ -87,7 +114,8 @@ describe('ServiceDashboard', () => {
   beforeEach(() => {
     mockFetch = vi.fn().mockImplementation((url: string) => {
       if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
-      if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+      if (pathOf(url).endsWith('/service/golf_hub'))
+        return ok(viewOf(url) === 'rate' ? rateScalarResponse : scalarResponse)
       // Keyed on the exact name so a request for the wrong container 404s
       // rather than being answered with golf_hub's stats.
       if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
@@ -123,7 +151,7 @@ describe('ServiceDashboard', () => {
 
     expect(screen.getByText('Sessions')).toBeTruthy()
     expect(screen.getByText('Activity')).toBeTruthy()
-    expect(screen.getByText('Commands Per Sec')).toBeTruthy()
+    expect(screen.getByText('Commands')).toBeTruthy()
     expect(screen.getByText('sessions')).toBeTruthy()
     // The custom series charts under Trends; the standard series does not.
     expect(screen.getByText('Trends')).toBeTruthy()
@@ -138,7 +166,7 @@ describe('ServiceDashboard', () => {
           text: () => Promise.resolve(JSON.stringify({ ...timeseriesResponse, series: [timeseriesResponse.series[0]] })),
         })
       }
-      if (url.endsWith('/service/golf_hub')) {
+      if (pathOf(url).endsWith('/service/golf_hub')) {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve(JSON.stringify({ ...scalarResponse, custom: [] })),
@@ -176,7 +204,7 @@ describe('ServiceDashboard', () => {
     })
     expect(screen.queryByText('Sessions')).toBeNull()
     const urls = mockFetch.mock.calls.map((call) => String(call[0]))
-    expect(urls.some((url) => url.endsWith('/service/portrait'))).toBe(true)
+    expect(urls.some((url) => pathOf(url).endsWith('/service/portrait'))).toBe(true)
   })
 
   it('charts the full selected window, not just the buckets with samples', async () => {
@@ -292,7 +320,7 @@ describe('ServiceDashboard', () => {
       // would be a 404 dressed up as a useful link.
       mockFetch.mockImplementation((url: string) => {
         if (url.endsWith('/container/golf_hub')) return ok(containerDetail({ version: '2-alpine' }))
-        if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+        if (pathOf(url).endsWith('/service/golf_hub')) return ok(scalarResponse)
         return ok(timeseriesResponse)
       })
       await renderAndSettle()
@@ -307,7 +335,7 @@ describe('ServiceDashboard', () => {
       // luck; truncating a longer tag would not. Only hex gets cut.
       mockFetch.mockImplementation((url: string) => {
         if (url.endsWith('/container/golf_hub')) return ok(containerDetail({ version: 'v2.1.0-rc.3' }))
-        if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+        if (pathOf(url).endsWith('/service/golf_hub')) return ok(scalarResponse)
         return ok(timeseriesResponse)
       })
       await renderAndSettle()
@@ -410,7 +438,7 @@ describe('ServiceDashboard', () => {
 
         mockFetch.mockImplementation((url: string) => {
           if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
-          if (url.endsWith('/service/golf_hub')) return ok(scalarResponse)
+          if (pathOf(url).endsWith('/service/golf_hub')) return ok(scalarResponse)
           return notFound()
         })
         await act(async () => {
@@ -433,5 +461,102 @@ describe('ServiceDashboard', () => {
 
       expect(screen.getByTestId('container-version').textContent).toBe('—')
     })
+  })
+
+  // --- The count/rate toggle (MoonBase#1287) --------------------------------
+
+  it('switches counter tiles between count and rate', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Default view is count, matching the proxy's own default.
+    expect(screen.getByText('12.0')).toBeTruthy()
+
+    const toggle = screen.getByLabelText('Counter view') as HTMLSelectElement
+    expect(toggle.value).toBe('count')
+
+    await act(async () => {
+      fireEvent.change(toggle, { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // The refetch asked for the other form, and the tile shows what came back.
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(urls.some((url) => pathOf(url).endsWith('/service/golf_hub') && viewOf(url) === 'rate')).toBe(true)
+    expect(screen.getByText('0.04')).toBeTruthy()
+    expect(screen.getByText('/s')).toBeTruthy()
+
+    // Same tile, same caption. A label naming one of the two forms would now
+    // be contradicting the number beside it.
+    expect(screen.getByText('Commands')).toBeTruthy()
+  })
+
+  it('leaves fixed-form tiles alone when the view changes', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Counter view'), { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // `active` is a gauge: it has no rate form, so it reads the same in both
+    // views and keeps its own unit rather than gaining a /s.
+    expect(screen.getByText('3.00')).toBeTruthy()
+    expect(screen.getByText('sessions')).toBeTruthy()
+  })
+
+  it('offers no toggle when the proxy sends no toggleable tiles', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
+      if (pathOf(url).endsWith('/service/golf_hub')) return ok(legacyScalarResponse)
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // A switch that changes nothing is worse than no switch: this payload is
+    // from a proxy that predates the feature, so there is nothing to toggle.
+    expect(screen.getByText('Sessions')).toBeTruthy()
+    expect(screen.queryByLabelText('Counter view')).toBeNull()
+  })
+
+  it('names the requests tile for what it now holds', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // requests_total stopped being cumulative in MoonBase#1287 but kept its
+    // JSON key, so the tile has to say which of the two it is showing.
+    expect(screen.getByText('Req (5m)')).toBeTruthy()
+    expect(screen.queryByText('Total')).toBeNull()
+  })
+
+  it('keeps the old label for a proxy still sending a lifetime total', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
+      if (pathOf(url).endsWith('/service/golf_hub')) return ok(legacyScalarResponse)
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Relabelling unconditionally would put "Req (5m)" over a number that is
+    // still a lifetime total on any host that has not rolled yet.
+    expect(screen.getByText('Total')).toBeTruthy()
+    expect(screen.queryByText('Req (5m)')).toBeNull()
   })
 })


### PR DESCRIPTION
The UI half of [MoonBase#1287](https://github.com/muchq/MoonBase/issues/1287), whose backend side is [MoonBase#1288](https://github.com/muchq/MoonBase/pull/1288).

## The toggle

That change gave `/service/{name}` a `?view=count|rate` parameter, had it echo the view back, and put a `toggleable` flag on each tile that has both forms. Counter tiles used to be fixed at declaration time — two tiles for one series, one captioned `_total` and one `_per_sec` — and are now one tile the caller picks a form for.

So this adds a second `<select>` beside the range picker. Tile labels lose their form suffix on the API side, because the same caption now has to read correctly over either number.

**The toggle renders only when the payload actually has a toggleable tile.** A service whose custom block is all gauges and windowed means has nothing to switch, and neither does a host still running an older prom_proxy. A control that changes nothing on screen is worse than no control.

`?view=` is sent unconditionally, which is safe against an older proxy: Go's mux ignores query parameters nothing reads, so the request succeeds and comes back in the only form that proxy has.

## The mislabelled tile

Separately, `requests_total` stopped being cumulative in the same backend change — it's a 5-minute `increase()` now, because a lifetime counter resets on every deploy and can't be compared across one. Its JSON key couldn't change without breaking this UI, so the field still says *total* while the number isn't one. The tile said **Total** over it.

It now says **Req (5m)** — but only when `view` is present in the payload. That field is the tell: it exists exactly when the proxy carries the change, because both landed in the same commit. Relabelling unconditionally would put a 5-minute caption over a genuine lifetime total on any host that hasn't rolled yet.

## Compatibility

Both new fields are optional in the types, matching how `service`, `reporting` and `last_seen_ago_seconds` are already handled here. Pages deploys independently of prom_proxy, so a payload from either side of the change has to render, and there are tests for both directions.

## On the renamed series

That backend change also renamed portrait's custom timeseries keys (`scene_sphere_count` → `scene_spheres_requested`, plus new `_rendered` variants). **No change needed here** — `customSeries` is everything not in `STANDARD_SERIES`, titled with `prettyLabel(metric_name)`, so a rename changes a chart's title and nothing else. Worth stating explicitly since the backend PR flagged it as needing confirmation from this side.

## Verification

- **395/395** vitest, `lint` and `typecheck` clean.
- **Four mutations, all killed**: `?view=` dropped from the request URL; the toggle rendered unconditionally; `requestsTotalLabel` pinned to the new string; `hasToggleableMetrics` forced false.
- New tests cover the switch changing both the requested view and the rendered value, fixed-form tiles being unaffected by it, the toggle's absence on a legacy payload, and both labels for the requests tile.
- No review panel ran against this commit.

## Merge order

Harmless either way — the toggle stays hidden and the tile keeps its old label until the backend is deployed — but this reads best merged after MoonBase#1288 has rolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_