### PR TITLE
metrics: Serving and Trends charts follow the count/rate toggle

### DIFF
--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -285,10 +285,6 @@ export interface TimeSeriesResponse {
   start_time: string
   end_time: string
   step: string
-  // Which form the toggleable series in this payload are in. Present on the
-  // service timeseries endpoint since request_rate gained a count form;
-  // absent on the host/container endpoints, which have no toggleable series.
-  view?: MetricView
   series: TimeSeries[]
 }
 

--- a/src/apps/metrics-systems/api.ts
+++ b/src/apps/metrics-systems/api.ts
@@ -59,12 +59,14 @@ export interface ServiceMetricsResponse {
 
 // Whether this payload has any tile worth offering a toggle for.
 //
-// Asked of the payload rather than assumed from the service, because it is a
-// property of what the proxy sent: a host running an older prom_proxy sends no
-// `toggleable` flags at all, and a switch that changes nothing on screen is
-// worse than no switch.
+// `view` is the signal, not a scan of `custom` for a `toggleable` flag: the
+// Serving section's Request Rate chart is counter-derived on every service —
+// even one with no custom block at all — so as of the proxy that started
+// echoing `view`, there is always something for the switch to change. A host
+// running an older prom_proxy sends no `view` at all, and a switch that
+// changes nothing on screen is worse than no switch.
 export function hasToggleableMetrics(response: ServiceMetricsResponse | null): boolean {
-  return !!response?.custom?.some((group) => group.metrics?.some((metric) => metric.toggleable))
+  return !!response?.view
 }
 
 // What to call the standard block's `requests_total` tile.
@@ -283,6 +285,10 @@ export interface TimeSeriesResponse {
   start_time: string
   end_time: string
   step: string
+  // Which form the toggleable series in this payload are in. Present on the
+  // service timeseries endpoint since request_rate gained a count form;
+  // absent on the host/container endpoints, which have no toggleable series.
+  view?: MetricView
   series: TimeSeries[]
 }
 

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -169,7 +169,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
         // back in the only form that proxy has. The switch stays hidden in
         // that case anyway — see hasToggleableMetrics.
         fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}?view=${view}`),
-        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
+        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}?view=${view}`),
         fetchJson<ContainerDetail>(`${METRICS_API_URL}/container/${service}`),
       ])
       if (!active) return
@@ -294,7 +294,19 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             </div>
           )}
           <div className={styles.sectionGrid}>
-            <SeriesChart title="Request Rate" series={findSeries('request_rate')} frame={frame} color={COLORS.primary} unit="req/s" emptyMessage={emptyMessage} />
+            {/* request_rate is the one standard series built from a counter,
+                so it's the one that answers to the view toggle: increase()
+                per bucket in count, rate() per second in rate. The other
+                three charts below have no count form and stay put — see
+                standardRequestRateQuery in prom_proxy's registry.go. */}
+            <SeriesChart
+              title={view === 'count' ? 'Requests' : 'Request Rate'}
+              series={findSeries('request_rate')}
+              frame={frame}
+              color={COLORS.primary}
+              unit={view === 'count' ? 'requests' : 'req/s'}
+              emptyMessage={emptyMessage}
+            />
             <SeriesChart title="Error Rate" series={findSeries('error_rate_percent')} frame={frame} color={COLORS.danger} unit="%" emptyMessage={emptyMessage} />
             <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} frame={frame} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area emptyMessage={emptyMessage} />
             <SeriesChart title="Active Requests" series={findSeries('active_requests')} frame={frame} color={COLORS.success} unit="" area emptyMessage={emptyMessage} />

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -26,21 +26,22 @@ interface ServiceDashboardProps {
   onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
 }
 
-// The six series every service page charts; anything else in the
+// The eight series every service page charts; anything else in the
 // timeseries payload is a custom series and renders generically below.
 // Must match the keys of standardTimeseriesQueries in prom_proxy's
 // registry.go — and custom series names must not collide with these, or
 // they classify as standard and never chart.
 //
-// request_rate and request_count are the same counter in its two forms —
-// always both present, never picked by a query param — so the Request Rate
-// chart below can switch which one it plots locally. See registry.go's
-// standardTimeseriesQueries for why they're separate keys rather than one
-// key whose meaning depends on ?view=.
+// request_rate/request_count and error_rate_percent/error_count are each the
+// same counter in two forms — always both present, never picked by a query
+// param — so the charts below can switch which one they plot locally. See
+// registry.go's standardTimeseriesQueries for why they're separate keys
+// rather than one key whose meaning depends on ?view=.
 const STANDARD_SERIES = new Set([
   'request_rate',
   'request_count',
   'error_rate_percent',
+  'error_count',
   'avg_duration_us',
   'p95_duration_us',
   'active_requests',
@@ -56,6 +57,48 @@ const formatValue = (value: number) => {
 
 const prettyLabel = (label: string) =>
   label.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+
+interface TrendEntry {
+  key: string
+  title: string
+  series: TimeSeries | undefined
+}
+
+// Collapses a service's custom series into what Trends actually renders. A
+// toggleable chart lands in the payload as two panels — <base>_rate and
+// <base>_count, prom_proxy's customTimeseriesDef.panels — and groups into
+// one chart here that picks between them by view, the same way the Serving
+// section's Request Rate chart does. Everything else — a gauge, a ratio, a
+// windowed mean — has no sibling to pair with and renders standalone under
+// its own name, same as before this existed.
+const groupTrends = (series: TimeSeries[], view: MetricView): TrendEntry[] => {
+  const byName = new Map(series.map((s) => [s.metric_name, s]))
+  const consumed = new Set<string>()
+  const entries: TrendEntry[] = []
+  for (const s of series) {
+    if (consumed.has(s.metric_name)) continue
+    const isRate = s.metric_name.endsWith('_rate')
+    const isCount = s.metric_name.endsWith('_count')
+    if (isRate || isCount) {
+      const base = s.metric_name.slice(0, isRate ? -'_rate'.length : -'_count'.length)
+      const rateKey = `${base}_rate`
+      const countKey = `${base}_count`
+      if (byName.has(rateKey) && byName.has(countKey)) {
+        consumed.add(rateKey)
+        consumed.add(countKey)
+        entries.push({
+          key: base,
+          title: view === 'count' ? prettyLabel(base) : `${prettyLabel(base)} Rate`,
+          series: view === 'count' ? byName.get(countKey) : byName.get(rateKey),
+        })
+        continue
+      }
+    }
+    consumed.add(s.metric_name)
+    entries.push({ key: s.metric_name, title: prettyLabel(s.metric_name), series: s })
+  }
+  return entries
+}
 
 const NoDataMessage = ({ message = 'No data available' }: { message?: string }) => (
   <div className={styles.noData}>{message}</div>
@@ -213,12 +256,15 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const standard = scalar?.standard
   const frame = seriesWindow(timeseries)
   const emptyMessage = loading ? 'Loading…' : undefined
-  // request_rate and request_count are always both in the payload (once the
-  // proxy carries MoonBase#1292) — no `view` to trust or distrust, just pick
-  // which one to plot. Against an older proxy that only ever sends
-  // request_rate, findSeries('request_count') comes back undefined and the
-  // chart shows its ordinary "no data" state rather than a mislabeled rate.
+  // request_rate/request_count and error_rate_percent/error_count are always
+  // both in the payload (once the proxy carries MoonBase#1292) — no `view`
+  // to trust or distrust, just pick which one to plot. Against an older
+  // proxy that only ever sends the rate form, findSeries(...'_count') comes
+  // back undefined and the chart shows its ordinary "no data" state rather
+  // than a mislabeled rate.
   const requestSeries = view === 'count' ? findSeries('request_count') : findSeries('request_rate')
+  const errorSeries = view === 'count' ? findSeries('error_count') : findSeries('error_rate_percent')
+  const trendEntries = groupTrends(customSeries, view)
 
   const COLORS = {
     primary: '#66b6ff',
@@ -312,11 +358,12 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             </div>
           )}
           <div className={styles.sectionGrid}>
-            {/* request_rate/request_count is the one standard pair built from
-                a counter, so it's the one the toggle picks between: increase()
-                per bucket in count, rate() per second in rate. The other three
-                charts below have no count-form sibling and stay put — see
-                standardTimeseriesQueries in prom_proxy's registry.go. */}
+            {/* request_rate/request_count and error_rate_percent/error_count
+                are the two standard pairs built from a counter, so they're
+                what the toggle picks between: increase() per bucket in
+                count, rate()/ratio per second in rate. P95 Latency and
+                Active Requests have no count-form sibling and stay put —
+                see standardTimeseriesQueries in prom_proxy's registry.go. */}
             <SeriesChart
               title={view === 'count' ? 'Requests' : 'Request Rate'}
               series={requestSeries}
@@ -325,7 +372,14 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
               unit={view === 'count' ? 'requests' : 'req/s'}
               emptyMessage={emptyMessage}
             />
-            <SeriesChart title="Error Rate" series={findSeries('error_rate_percent')} frame={frame} color={COLORS.danger} unit="%" emptyMessage={emptyMessage} />
+            <SeriesChart
+              title={view === 'count' ? 'Errors' : 'Error Rate'}
+              series={errorSeries}
+              frame={frame}
+              color={COLORS.danger}
+              unit={view === 'count' ? 'errors' : '%'}
+              emptyMessage={emptyMessage}
+            />
             <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} frame={frame} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area emptyMessage={emptyMessage} />
             <SeriesChart title="Active Requests" series={findSeries('active_requests')} frame={frame} color={COLORS.success} unit="" area emptyMessage={emptyMessage} />
           </div>
@@ -349,16 +403,20 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
           </div>
         ))}
 
-        {/* Every non-standard series charts generically. */}
-        {customSeries.length > 0 && (
+        {/* Every non-standard series charts generically. A toggleable pair
+            (base_rate + base_count) collapses into one chart that follows
+            the count/rate toggle, same as the Serving section — see
+            groupTrends. Anything else — a gauge, a ratio, a windowed mean —
+            has no sibling to pair with and stays put. */}
+        {trendEntries.length > 0 && (
           <div className={styles.section}>
             <h2 className={styles.sectionTitle}>Trends</h2>
             <div className={styles.sectionGrid}>
-              {customSeries.map((series, index) => (
+              {trendEntries.map((entry, index) => (
                 <SeriesChart
-                  key={series.metric_name}
-                  title={prettyLabel(series.metric_name)}
-                  series={series}
+                  key={entry.key}
+                  title={entry.title}
+                  series={entry.series}
                   frame={frame}
                   color={[COLORS.primary, COLORS.info, COLORS.success, COLORS.warning][index % 4]}
                   unit=""

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -26,7 +26,7 @@ interface ServiceDashboardProps {
   onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
 }
 
-// The eight series every service page charts; anything else in the
+// The seven series every service page charts; anything else in the
 // timeseries payload is a custom series and renders generically below.
 // Must match the keys of standardTimeseriesQueries in prom_proxy's
 // registry.go — and custom series names must not collide with these, or
@@ -62,6 +62,7 @@ interface TrendEntry {
   key: string
   title: string
   series: TimeSeries | undefined
+  unit: string
 }
 
 // Collapses a service's custom series into what Trends actually renders. A
@@ -70,7 +71,9 @@ interface TrendEntry {
 // one chart here that picks between them by view, the same way the Serving
 // section's Request Rate chart does. Everything else — a gauge, a ratio, a
 // windowed mean — has no sibling to pair with and renders standalone under
-// its own name, same as before this existed.
+// its own name with no unit, same as before this existed: the payload
+// carries no per-series unit for Trends, so a standalone chart has nothing
+// to show beyond its own values.
 const groupTrends = (series: TimeSeries[], view: MetricView): TrendEntry[] => {
   const byName = new Map(series.map((s) => [s.metric_name, s]))
   const consumed = new Set<string>()
@@ -90,14 +93,49 @@ const groupTrends = (series: TimeSeries[], view: MetricView): TrendEntry[] => {
           key: base,
           title: view === 'count' ? prettyLabel(base) : `${prettyLabel(base)} Rate`,
           series: view === 'count' ? byName.get(countKey) : byName.get(rateKey),
+          // Unlike the Serving pairs, a Trends counter's unit is unlabeled
+          // upstream, so there's no bare unit to append "/s" to — just the
+          // form cue itself, the same "/s" a unitless scalar tile gets from
+          // UnitFor in the rate view.
+          unit: view === 'count' ? '' : '/s',
         })
         continue
       }
     }
     consumed.add(s.metric_name)
-    entries.push({ key: s.metric_name, title: prettyLabel(s.metric_name), series: s })
+    entries.push({ key: s.metric_name, title: prettyLabel(s.metric_name), series: s, unit: '' })
   }
   return entries
+}
+
+interface SeriesPick {
+  series: TimeSeries | undefined
+  form: MetricView
+}
+
+// Picks which form of a Serving toggle pair (request_rate/request_count,
+// error_rate_percent/error_count) to plot: the requested view's series when
+// it exists, otherwise whichever sibling does. A bare `view === 'count' ?
+// count : rate` pick goes blank by default against a proxy that predates
+// the count form — DefaultView is count, so every service page's Serving
+// charts would render "No data" until someone flipped to rate, real data
+// sitting unused in the same payload the whole time. Falling back to
+// whichever form the payload actually has is the same availability rule
+// groupTrends already gets from only pairing when both siblings exist.
+const pickSeriesForView = (
+  series: TimeSeries[],
+  countName: string,
+  rateName: string,
+  view: MetricView,
+): SeriesPick => {
+  const byName = new Map(series.map((s) => [s.metric_name, s]))
+  const count = byName.get(countName)
+  const rate = byName.get(rateName)
+  if (view === 'count' && count) return { series: count, form: 'count' }
+  if (view === 'rate' && rate) return { series: rate, form: 'rate' }
+  if (rate) return { series: rate, form: 'rate' }
+  if (count) return { series: count, form: 'count' }
+  return { series: undefined, form: view }
 }
 
 const NoDataMessage = ({ message = 'No data available' }: { message?: string }) => (
@@ -256,14 +294,8 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const standard = scalar?.standard
   const frame = seriesWindow(timeseries)
   const emptyMessage = loading ? 'Loading…' : undefined
-  // request_rate/request_count and error_rate_percent/error_count are always
-  // both in the payload (once the proxy carries MoonBase#1292) — no `view`
-  // to trust or distrust, just pick which one to plot. Against an older
-  // proxy that only ever sends the rate form, findSeries(...'_count') comes
-  // back undefined and the chart shows its ordinary "no data" state rather
-  // than a mislabeled rate.
-  const requestSeries = view === 'count' ? findSeries('request_count') : findSeries('request_rate')
-  const errorSeries = view === 'count' ? findSeries('error_count') : findSeries('error_rate_percent')
+  const requestPick = pickSeriesForView(timeseries?.series ?? [], 'request_count', 'request_rate', view)
+  const errorPick = pickSeriesForView(timeseries?.series ?? [], 'error_count', 'error_rate_percent', view)
   const trendEntries = groupTrends(customSeries, view)
 
   const COLORS = {
@@ -361,23 +393,28 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             {/* request_rate/request_count and error_rate_percent/error_count
                 are the two standard pairs built from a counter, so they're
                 what the toggle picks between: increase() per bucket in
-                count, rate()/ratio per second in rate. P95 Latency and
-                Active Requests have no count-form sibling and stay put —
-                see standardTimeseriesQueries in prom_proxy's registry.go. */}
+                count, rate()/ratio per second in rate. Title/unit read the
+                pick's own form, not the raw toggle state — pickSeriesForView
+                falls back to whichever sibling the payload actually has, so
+                a proxy that hasn't caught up to the count form yet still
+                gets an honest "Request Rate" label over real data instead of
+                a blank "Requests" chart. P95 Latency and Active Requests
+                have no count-form sibling and stay put — see
+                standardTimeseriesQueries in prom_proxy's registry.go. */}
             <SeriesChart
-              title={view === 'count' ? 'Requests' : 'Request Rate'}
-              series={requestSeries}
+              title={requestPick.form === 'count' ? 'Requests' : 'Request Rate'}
+              series={requestPick.series}
               frame={frame}
               color={COLORS.primary}
-              unit={view === 'count' ? 'requests' : 'req/s'}
+              unit={requestPick.form === 'count' ? 'requests' : 'req/s'}
               emptyMessage={emptyMessage}
             />
             <SeriesChart
-              title={view === 'count' ? 'Errors' : 'Error Rate'}
-              series={errorSeries}
+              title={errorPick.form === 'count' ? 'Errors' : 'Error Rate'}
+              series={errorPick.series}
               frame={frame}
               color={COLORS.danger}
-              unit={view === 'count' ? 'errors' : '%'}
+              unit={errorPick.form === 'count' ? 'errors' : '%'}
               emptyMessage={emptyMessage}
             />
             <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} frame={frame} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area emptyMessage={emptyMessage} />
@@ -419,7 +456,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
                   series={entry.series}
                   frame={frame}
                   color={[COLORS.primary, COLORS.info, COLORS.success, COLORS.warning][index % 4]}
-                  unit=""
+                  unit={entry.unit}
                   emptyMessage={emptyMessage}
                 />
               ))}

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -26,13 +26,20 @@ interface ServiceDashboardProps {
   onConnectionStateChange: (status: 'connecting' | 'connected' | 'disconnected' | 'failed') => void
 }
 
-// The five series every service page charts; anything else in the
+// The six series every service page charts; anything else in the
 // timeseries payload is a custom series and renders generically below.
 // Must match the keys of standardTimeseriesQueries in prom_proxy's
 // registry.go — and custom series names must not collide with these, or
 // they classify as standard and never chart.
+//
+// request_rate and request_count are the same counter in its two forms —
+// always both present, never picked by a query param — so the Request Rate
+// chart below can switch which one it plots locally. See registry.go's
+// standardTimeseriesQueries for why they're separate keys rather than one
+// key whose meaning depends on ?view=.
 const STANDARD_SERIES = new Set([
   'request_rate',
+  'request_count',
   'error_rate_percent',
   'avg_duration_us',
   'p95_duration_us',
@@ -169,7 +176,10 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
         // back in the only form that proxy has. The switch stays hidden in
         // that case anyway — see hasToggleableMetrics.
         fetchJson<ServiceMetricsResponse>(`${METRICS_API_URL}/service/${service}?view=${view}`),
-        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}?view=${view}`),
+        // No ?view= here: the timeseries endpoint always answers with both
+        // request_rate and request_count, and the chart below picks between
+        // them locally — see STANDARD_SERIES.
+        fetchJson<TimeSeriesResponse>(`${METRICS_API_URL}/service/${service}/timeseries/${timeRange}`),
         fetchJson<ContainerDetail>(`${METRICS_API_URL}/container/${service}`),
       ])
       if (!active) return
@@ -203,6 +213,12 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
   const standard = scalar?.standard
   const frame = seriesWindow(timeseries)
   const emptyMessage = loading ? 'Loading…' : undefined
+  // request_rate and request_count are always both in the payload (once the
+  // proxy carries MoonBase#1292) — no `view` to trust or distrust, just pick
+  // which one to plot. Against an older proxy that only ever sends
+  // request_rate, findSeries('request_count') comes back undefined and the
+  // chart shows its ordinary "no data" state rather than a mislabeled rate.
+  const requestSeries = view === 'count' ? findSeries('request_count') : findSeries('request_rate')
 
   const COLORS = {
     primary: '#66b6ff',
@@ -226,10 +242,12 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             <option value="1d">1d</option>
             <option value="7d">7d</option>
           </select>
-          {/* Only when the payload actually has counter tiles to switch. A
-              service whose custom block is all gauges and windowed means has
-              nothing this would change, and neither does a host still running
-              a pre-MoonBase#1287 proxy. */}
+          {/* Only when the proxy is new enough to answer a view at all. Every
+              service's Serving chart has a toggleable Request Rate — even one
+              whose custom block is all gauges and windowed means — so the
+              only payload with nothing for this to change is one from a
+              pre-MoonBase#1287 proxy, which sends no `view` in the first
+              place. */}
           {hasToggleableMetrics(scalar) && (
             <select
               value={view}
@@ -294,14 +312,14 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
             </div>
           )}
           <div className={styles.sectionGrid}>
-            {/* request_rate is the one standard series built from a counter,
-                so it's the one that answers to the view toggle: increase()
-                per bucket in count, rate() per second in rate. The other
-                three charts below have no count form and stay put — see
-                standardRequestRateQuery in prom_proxy's registry.go. */}
+            {/* request_rate/request_count is the one standard pair built from
+                a counter, so it's the one the toggle picks between: increase()
+                per bucket in count, rate() per second in rate. The other three
+                charts below have no count-form sibling and stay put — see
+                standardTimeseriesQueries in prom_proxy's registry.go. */}
             <SeriesChart
               title={view === 'count' ? 'Requests' : 'Request Rate'}
-              series={findSeries('request_rate')}
+              series={requestSeries}
               frame={frame}
               color={COLORS.primary}
               unit={view === 'count' ? 'requests' : 'req/s'}

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -247,8 +247,11 @@ describe('ServiceDashboard', () => {
       await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
+    // The timeseries endpoint is fetched with ?view= too now, so endsWith on
+    // the whole URL no longer matches it — same reason pathOf/viewOf exist
+    // for the scalar endpoint above.
     const urls = mockFetch.mock.calls.map((call) => String(call[0]))
-    expect(urls.some((url) => url.endsWith('/service/golf_hub/timeseries/30m'))).toBe(true)
+    expect(urls.some((url) => pathOf(url).endsWith('/service/golf_hub/timeseries/30m'))).toBe(true)
   })
 
   it('reports failure and keeps the page shape when the API is down', async () => {
@@ -508,6 +511,34 @@ describe('ServiceDashboard', () => {
     // views and keeps its own unit rather than gaining a /s.
     expect(screen.getByText('3.00')).toBeTruthy()
     expect(screen.getByText('sessions')).toBeTruthy()
+  })
+
+  it('sends the view to the timeseries endpoint too, and relabels the Request Rate chart', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // Default view is count: the standard chart built from a counter reads
+    // as a count too, not stuck on rate while the tiles beside it toggle.
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(
+      urls.some((url) => pathOf(url).includes('/service/golf_hub/timeseries/') && viewOf(url) === 'count'),
+    ).toBe(true)
+    expect(screen.getByText('Requests')).toBeTruthy()
+    expect(screen.queryByText('Request Rate')).toBeNull()
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Counter view'), { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const urlsAfterToggle = mockFetch.mock.calls.map((call) => String(call[0]))
+    expect(
+      urlsAfterToggle.some((url) => pathOf(url).includes('/service/golf_hub/timeseries/') && viewOf(url) === 'rate'),
+    ).toBe(true)
+    expect(screen.getByText('Request Rate')).toBeTruthy()
+    expect(screen.queryByText('Requests')).toBeNull()
   })
 
   it('offers no toggle when the proxy sends no toggleable tiles', async () => {

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -547,6 +547,79 @@ describe('ServiceDashboard', () => {
     expect(screen.queryByText('Requests')).toBeNull()
   })
 
+  it('switches the Error Rate chart between error_count and error_rate_percent', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) {
+        return ok({
+          ...timeseriesResponse,
+          series: [
+            ...timeseriesResponse.series,
+            { metric_name: 'error_rate_percent', values: [{ timestamp: new Date().toISOString(), value: 4.8 }] },
+            { metric_name: 'error_count', values: [{ timestamp: new Date().toISOString(), value: 3 }] },
+          ],
+        })
+      }
+      if (pathOf(url).endsWith('/service/golf_hub'))
+        return ok(viewOf(url) === 'rate' ? rateScalarResponse : scalarResponse)
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Errors')).toBeTruthy()
+    expect(screen.queryByText('Error Rate')).toBeNull()
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Counter view'), { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Error Rate')).toBeTruthy()
+    expect(screen.queryByText('Errors')).toBeNull()
+  })
+
+  it('groups a toggleable Trends pair into one chart that follows the toggle', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) {
+        return ok({
+          ...timeseriesResponse,
+          series: [
+            ...timeseriesResponse.series,
+            { metric_name: 'command_rate', values: [{ timestamp: new Date().toISOString(), value: 0.5 }] },
+            { metric_name: 'command_count', values: [{ timestamp: new Date().toISOString(), value: 15 }] },
+          ],
+        })
+      }
+      if (pathOf(url).endsWith('/service/golf_hub'))
+        return ok(viewOf(url) === 'rate' ? rateScalarResponse : scalarResponse)
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // One chart, not two — the pair collapses under the toggle rather than
+    // command_rate and command_count rendering as separate Trends entries.
+    expect(screen.getByText('Command')).toBeTruthy()
+    expect(screen.queryByText('Command Rate')).toBeNull()
+    expect(screen.queryByText('Command Count')).toBeNull()
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Counter view'), { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.getByText('Command Rate')).toBeTruthy()
+    expect(screen.queryByText('Command')).toBeNull()
+  })
+
   it('shows no data for the Serving chart, not a mislabeled rate, against a proxy with no request_count series', async () => {
     // The toggle asks for count (the default) and the scalar side answers it
     // — but the timeseries side is still a pre-MoonBase#1292 proxy that has

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -62,6 +62,9 @@ const legacyScalarResponse = {
   ],
 }
 
+// request_rate and request_count are both always present (MoonBase#1292) —
+// no ?view= on this endpoint, no picking one or the other server-side. The
+// component picks locally which one to plot.
 const timeseriesResponse = {
   time_range: '1d',
   start_time: new Date(Date.now() - 86400000).toISOString(),
@@ -69,8 +72,16 @@ const timeseriesResponse = {
   step: '30s',
   series: [
     { metric_name: 'request_rate', values: [{ timestamp: new Date().toISOString(), value: 1.2 }] },
+    { metric_name: 'request_count', values: [{ timestamp: new Date().toISOString(), value: 36 }] },
     { metric_name: 'sessions_active', values: [{ timestamp: new Date().toISOString(), value: 3 }] },
   ],
+}
+
+// A host still running a pre-MoonBase#1292 proxy: request_rate only, no
+// request_count series to switch to at all.
+const legacyTimeseriesResponse = {
+  ...timeseriesResponse,
+  series: timeseriesResponse.series.filter((s) => s.metric_name !== 'request_count'),
 }
 
 // A healthy container, with the fields MoonBase#1218 added. Overrides let each
@@ -513,7 +524,7 @@ describe('ServiceDashboard', () => {
     expect(screen.getByText('sessions')).toBeTruthy()
   })
 
-  it('sends the view to the timeseries endpoint too, and relabels the Request Rate chart', async () => {
+  it('switches the Serving chart between request_count and request_rate', async () => {
     render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 100))
@@ -521,10 +532,9 @@ describe('ServiceDashboard', () => {
 
     // Default view is count: the standard chart built from a counter reads
     // as a count too, not stuck on rate while the tiles beside it toggle.
-    const urls = mockFetch.mock.calls.map((call) => String(call[0]))
-    expect(
-      urls.some((url) => pathOf(url).includes('/service/golf_hub/timeseries/') && viewOf(url) === 'count'),
-    ).toBe(true)
+    // Both series are already in the one timeseries payload — the endpoint
+    // takes no ?view= at all — so this is a pure client-side pick, unlike
+    // the scalar tiles beside it which do refetch for the new view.
     expect(screen.getByText('Requests')).toBeTruthy()
     expect(screen.queryByText('Request Rate')).toBeNull()
 
@@ -533,15 +543,38 @@ describe('ServiceDashboard', () => {
       await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
-    const urlsAfterToggle = mockFetch.mock.calls.map((call) => String(call[0]))
-    expect(
-      urlsAfterToggle.some((url) => pathOf(url).includes('/service/golf_hub/timeseries/') && viewOf(url) === 'rate'),
-    ).toBe(true)
     expect(screen.getByText('Request Rate')).toBeTruthy()
     expect(screen.queryByText('Requests')).toBeNull()
   })
 
-  it('offers no toggle when the proxy sends no toggleable tiles', async () => {
+  it('shows no data for the Serving chart, not a mislabeled rate, against a proxy with no request_count series', async () => {
+    // The toggle asks for count (the default) and the scalar side answers it
+    // — but the timeseries side is still a pre-MoonBase#1292 proxy that has
+    // never heard of request_count. findSeries comes back undefined rather
+    // than the chart falling back to plotting request_rate under a "Requests"
+    // caption.
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/service/golf_hub/timeseries/')) return ok(legacyTimeseriesResponse)
+      if (pathOf(url).endsWith('/service/golf_hub'))
+        return ok(viewOf(url) === 'rate' ? rateScalarResponse : scalarResponse)
+      if (url.endsWith('/container/golf_hub')) return ok(containerDetail())
+      return notFound()
+    })
+
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // The custom tile did switch to count (12.0, the scalar side's own
+    // answer) — the Serving chart is titled for count too, since that's
+    // still what the toggle asked for, but has nothing to plot.
+    expect(screen.getByText('12.0')).toBeTruthy()
+    expect(screen.getByText('Requests')).toBeTruthy()
+    expect(screen.queryByText('Request Rate')).toBeNull()
+  })
+
+  it('offers no toggle when the proxy sends no view at all', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/service/golf_hub/timeseries/')) return ok(timeseriesResponse)
       if (pathOf(url).endsWith('/service/golf_hub')) return ok(legacyScalarResponse)

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -258,11 +258,11 @@ describe('ServiceDashboard', () => {
       await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
-    // The timeseries endpoint is fetched with ?view= too now, so endsWith on
-    // the whole URL no longer matches it — same reason pathOf/viewOf exist
-    // for the scalar endpoint above.
+    // The timeseries endpoint takes no ?view= — request_rate/request_count
+    // (and their error_* counterparts) always come back together, and the
+    // toggle picks between them client-side — so plain endsWith matches it.
     const urls = mockFetch.mock.calls.map((call) => String(call[0]))
-    expect(urls.some((url) => pathOf(url).endsWith('/service/golf_hub/timeseries/30m'))).toBe(true)
+    expect(urls.some((url) => url.endsWith('/service/golf_hub/timeseries/30m'))).toBe(true)
   })
 
   it('reports failure and keeps the page shape when the API is down', async () => {
@@ -620,12 +620,14 @@ describe('ServiceDashboard', () => {
     expect(screen.queryByText('Command')).toBeNull()
   })
 
-  it('shows no data for the Serving chart, not a mislabeled rate, against a proxy with no request_count series', async () => {
+  it('falls back to Request Rate with real data against a proxy with no request_count series', async () => {
     // The toggle asks for count (the default) and the scalar side answers it
     // — but the timeseries side is still a pre-MoonBase#1292 proxy that has
-    // never heard of request_count. findSeries comes back undefined rather
-    // than the chart falling back to plotting request_rate under a "Requests"
-    // caption.
+    // never heard of request_count. pickSeriesForView falls back to
+    // request_rate rather than leaving the chart captioned "Requests" over
+    // nothing: DefaultView is count, so a bare view-driven pick would blank
+    // every service page's Serving chart on the default path until someone
+    // manually flipped to rate, real rate data sitting unused the whole time.
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/service/golf_hub/timeseries/')) return ok(legacyTimeseriesResponse)
       if (pathOf(url).endsWith('/service/golf_hub'))
@@ -640,11 +642,17 @@ describe('ServiceDashboard', () => {
     })
 
     // The custom tile did switch to count (12.0, the scalar side's own
-    // answer) — the Serving chart is titled for count too, since that's
-    // still what the toggle asked for, but has nothing to plot.
+    // answer) — the scalar and timeseries endpoints are independent, and only
+    // the latter is stuck on the old proxy here.
     expect(screen.getByText('12.0')).toBeTruthy()
-    expect(screen.getByText('Requests')).toBeTruthy()
-    expect(screen.queryByText('Request Rate')).toBeNull()
+
+    // The Serving chart falls back to its rate label and plots real data,
+    // rather than an empty "Requests" chart with rate data sitting unused in
+    // the same payload.
+    expect(screen.queryByText('Requests')).toBeNull()
+    const requestChart = screen.getByText('Request Rate').parentElement as HTMLElement
+    expect(within(requestChart).queryByText('No data available')).toBeNull()
+    expect(within(requestChart).getByTestId('line-chart')).toBeTruthy()
   })
 
   it('offers no toggle when the proxy sends no view at all', async () => {


### PR DESCRIPTION
## Summary

- The count/rate toggle only ever affected custom scalar tiles (Indexing, Motifs, etc.) — the Serving section's charts and per-service Trends charts stayed on rate() regardless of the toggle. Companion backend PR: muchq/MoonBase#1292.
- Request Rate, Error Rate, and any toggleable Trends chart (a `<base>_rate`/`<base>_count` pair from the backend's `customTimeseriesDef.panels`) now pick between their two series client-side, driven by the same `view` state that already drives the scalar tiles.
- No `?view=` on the timeseries fetch at all — the endpoint always returns every series unconditionally, and picking which one to plot is pure client-side logic (`pickSeriesForView` for the two Serving pairs, `groupTrends` for Trends pairs). That keeps the deploy-safety property MoonBase#1292 settled on: no key's meaning depends on a query parameter, so neither side can mislabel the other's data regardless of rollout order.
- `pickSeriesForView` falls back to whichever form of a Serving pair the payload actually has when the requested one is missing, rather than rendering an empty chart while real data sits unused — the same availability rule Trends already gets for free from only pairing when both siblings exist. Without this, a proxy that hasn't picked up MoonBase#1292 yet would render blank Request/Error charts on every service page by default (`view` defaults to `count`).

## Deploy order

Frontend-first (or together) is the safe rollout: an old backend just means Serving falls back to its rate label with real data, and Trends renders any not-yet-paired series standalone under its own name — no mislabeling either way. Backend-first is the other hazard: an old frontend classifies any series it doesn't recognize as a custom Trends chart, so the new `*_count` series would show up as unwanted extra charts until the frontend catches up. See MoonBase#1292's description for the fuller writeup.

## Test plan

- [x] `npx vitest run` — 399/399 passing
- [x] `npx eslint src/apps/metrics-systems` — clean
- [x] `npx tsc --noEmit` — clean