### PR TITLE
golf: make knocking impossible to miss

### DIFF
--- a/src/apps/golf/components/GolfGame.module.css
+++ b/src/apps/golf/components/GolfGame.module.css
@@ -603,6 +603,120 @@
   animation: slideUp 0.3s ease;
 }
 
+/* Final round (knocked) styles */
+.finalRoundBanner {
+  width: 100%;
+  text-align: center;
+  font-family: 'Lexend', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.6rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fecaca;
+}
+
+.finalRoundBannerUrgent {
+  background: #b91c1c;
+  color: white;
+  box-shadow: 0 0 20px rgba(239, 68, 68, 0.6);
+  animation: knockBannerPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes knockBannerPulse {
+  0%, 100% { background: #b91c1c; }
+  50% { background: #ef4444; }
+}
+
+.finalRoundBackdrop {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 90;
+  background: radial-gradient(ellipse at center, rgba(220, 38, 38, 0) 35%, rgba(153, 27, 27, 0.55) 100%);
+  box-shadow: inset 0 0 0 5px rgba(239, 68, 68, 0.9), inset 0 0 90px rgba(185, 28, 28, 0.6);
+  animation: knockThrob 1.6s ease-in-out infinite;
+}
+
+@keyframes knockThrob {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+.knockAlertOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(127, 15, 15, 0.94);
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  animation: knockFlash 0.8s ease-in-out 3;
+}
+
+@keyframes knockFlash {
+  0%, 100% { background-color: rgba(127, 15, 15, 0.94); }
+  50% { background-color: rgba(220, 38, 38, 0.94); }
+}
+
+.knockAlertContent {
+  text-align: center;
+  padding: 1rem;
+}
+
+.knockAlertEmoji {
+  font-size: 5rem;
+  margin-bottom: 1rem;
+  animation: knockShake 0.8s ease-in-out infinite;
+}
+
+@keyframes knockShake {
+  0%, 100% { transform: rotate(0deg); }
+  20% { transform: rotate(-12deg) translateX(-6px); }
+  40% { transform: rotate(10deg) translateX(5px); }
+  60% { transform: rotate(-8deg) translateX(-4px); }
+  80% { transform: rotate(6deg) translateX(3px); }
+}
+
+.knockAlertTitle {
+  font-size: 2.5rem;
+  color: white;
+  font-family: 'Lexend', sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.knockAlertSubtitle {
+  font-size: 1.2rem;
+  color: #fecaca;
+  font-family: 'Lexend', sans-serif;
+  margin: 0.75rem 0 0 0;
+}
+
+.knockAlertTap {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  font-family: 'Lexend', sans-serif;
+  margin: 2rem 0 0 0;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .finalRoundBannerUrgent,
+  .finalRoundBackdrop,
+  .knockAlertOverlay,
+  .knockAlertEmoji,
+  .knockAlertTap {
+    animation: none;
+  }
+}
+
 .peekCountdown {
   position: fixed;
   top: 20px;
@@ -848,6 +962,23 @@
     font-size: 2rem;
   }
 
+  .finalRoundBanner {
+    font-size: 0.8rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .knockAlertEmoji {
+    font-size: 4rem;
+  }
+
+  .knockAlertTitle {
+    font-size: 1.8rem;
+  }
+
+  .knockAlertSubtitle {
+    font-size: 1rem;
+  }
+
   .playerArea {
     padding: 1rem;
     width: 100%;
@@ -1059,6 +1190,14 @@
 
   .celebrationTitle {
     font-size: 1.75rem;
+  }
+
+  .knockAlertEmoji {
+    font-size: 3.5rem;
+  }
+
+  .knockAlertTitle {
+    font-size: 1.5rem;
   }
 
   .playAgainButton {

--- a/src/apps/golf/components/GolfGame.module.css
+++ b/src/apps/golf/components/GolfGame.module.css
@@ -601,6 +601,9 @@
   border-radius: 0.5rem;
   font-family: 'Lexend', sans-serif;
   animation: slideUp 0.3s ease;
+  /* Above the knock alert (1100): error toasts must stay visible on a
+     player's last turn. */
+  z-index: 1200;
 }
 
 /* Final round (knocked) styles */
@@ -627,14 +630,18 @@
 
 @keyframes knockBannerPulse {
   0%, 100% { background: #b91c1c; }
-  50% { background: #ef4444; }
+  /* #dc2626, not brighter: white text must hold AA contrast at the
+     pulse's bright phase too. */
+  50% { background: #dc2626; }
 }
 
 .finalRoundBackdrop {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 90;
+  /* Below the room chat surfaces (z 30-50): the vignette themes the
+     table, it must not wash over the chat panel or toasts. */
+  z-index: 20;
   background: radial-gradient(ellipse at center, rgba(220, 38, 38, 0) 35%, rgba(153, 27, 27, 0.55) 100%);
   box-shadow: inset 0 0 0 5px rgba(239, 68, 68, 0.9), inset 0 0 90px rgba(185, 28, 28, 0.6);
   animation: knockThrob 1.6s ease-in-out infinite;
@@ -965,6 +972,14 @@
   .finalRoundBanner {
     font-size: 0.8rem;
     padding: 0.5rem 0.75rem;
+  }
+
+  /* Softer vignette on small screens: the deck pile and full-width
+     action buttons sit near the viewport edge where the glow is
+     strongest, and they must stay legible for the whole final round. */
+  .finalRoundBackdrop {
+    background: radial-gradient(ellipse at center, rgba(220, 38, 38, 0) 45%, rgba(153, 27, 27, 0.35) 100%);
+    box-shadow: inset 0 0 0 3px rgba(239, 68, 68, 0.9), inset 0 0 45px rgba(185, 28, 28, 0.4);
   }
 
   .knockAlertEmoji {

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -113,6 +113,21 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
     }
   }, [gameState?.gamePhase])
 
+  // Final round: from the knock until the game ends. Non-knockers get a
+  // full-screen alert (auto-dismissed so it can't block their last turn)
+  // plus a persistent red theme; the knocker just gets a calm banner.
+  const knockerId = gameState?.knockedPlayerId ?? null
+  const isFinalRound = gameState?.gamePhase === 'knocked'
+  const isKnocker = knockerId !== null && knockerId === playerId
+  const [knockAlertDismissed, setKnockAlertDismissed] = useState(false)
+
+  useEffect(() => {
+    const timer = isFinalRound
+      ? setTimeout(() => setKnockAlertDismissed(true), 5000)
+      : setTimeout(() => setKnockAlertDismissed(false), 0)
+    return () => clearTimeout(timer)
+  }, [isFinalRound])
+
   const renderCard = (card: Card | null, index: number, isRevealed: boolean, isPlayer: boolean) => {
     const canInteract = isPlayer && (isMyTurn || (currentPlayer && !currentPlayer.hasPeeked && gameState?.gamePhase === 'playing'))
 
@@ -445,7 +460,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
             <h2>Room: {gameState.id}</h2>
             <div className={styles.playerList}>
               {gameState.players.map((player, index) => {
-                const isActivePlayer = index === gameState.currentPlayerIndex && gameState.gamePhase === 'playing'
+                const isActivePlayer = index === gameState.currentPlayerIndex && (gameState.gamePhase === 'playing' || gameState.gamePhase === 'knocked')
                 return (
                   <div
                     key={player.id}
@@ -601,6 +616,14 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
 
       {gameState.gamePhase !== 'waiting' && currentPlayer && (
         <div className={styles.gameArea}>
+          {isFinalRound && (
+            <div className={`${styles.finalRoundBanner} ${!isKnocker ? styles.finalRoundBannerUrgent : ''}`}>
+              {isKnocker
+                ? 'You knocked — final round!'
+                : `🚨 Final round — ${knockerId} knocked! 🚨`}
+            </div>
+          )}
+
           {/* Turn indicator */}
           <div className={styles.turnIndicator}>
             {!isMyTurn ? (
@@ -608,7 +631,7 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
             ) : !currentPlayer.hasPeeked && gameState.gamePhase === 'playing' ? (
               <span>Tap {2 - currentPlayer.revealedCards.length} cards to peek</span>
             ) : !gameState.drawnCard ? (
-              <span>Your turn — tap a pile to draw</span>
+              <span>{isFinalRound ? 'Your last turn — tap a pile to draw' : 'Your turn — tap a pile to draw'}</span>
             ) : (
               <span>Tap a card to swap, or discard</span>
             )}
@@ -684,6 +707,25 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
                 </button>
               )}
             </div>
+          </div>
+        </div>
+      )}
+
+      {isFinalRound && !isKnocker && (
+        <div className={styles.finalRoundBackdrop} aria-hidden="true" />
+      )}
+
+      {isFinalRound && !isKnocker && !knockAlertDismissed && (
+        <div
+          className={styles.knockAlertOverlay}
+          role="alert"
+          onClick={() => setKnockAlertDismissed(true)}
+        >
+          <div className={styles.knockAlertContent}>
+            <div className={styles.knockAlertEmoji}>✊</div>
+            <h2 className={styles.knockAlertTitle}>{knockerId} knocked!</h2>
+            <p className={styles.knockAlertSubtitle}>This is your last turn — make it count!</p>
+            <p className={styles.knockAlertTap}>Tap to continue</p>
           </div>
         </div>
       )}

--- a/src/apps/golf/components/GolfGame.tsx
+++ b/src/apps/golf/components/GolfGame.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import styles from './GolfGame.module.css'
 import { useGolfGame } from '@/hooks/useGolfGame'
 import PermalinkDisplay from './PermalinkDisplay'
@@ -120,6 +120,8 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
   const isFinalRound = gameState?.gamePhase === 'knocked'
   const isKnocker = knockerId !== null && knockerId === playerId
   const [knockAlertDismissed, setKnockAlertDismissed] = useState(false)
+  const showKnockAlert = isFinalRound && !isKnocker && !knockAlertDismissed
+  const knockAlertRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const timer = isFinalRound
@@ -127,6 +129,12 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
       : setTimeout(() => setKnockAlertDismissed(false), 0)
     return () => clearTimeout(timer)
   }, [isFinalRound])
+
+  // Focus the alert while it's up so keyboard users can dismiss it —
+  // tapping is not the only input this game gets.
+  useEffect(() => {
+    if (showKnockAlert) knockAlertRef.current?.focus()
+  }, [showKnockAlert])
 
   const renderCard = (card: Card | null, index: number, isRevealed: boolean, isPlayer: boolean) => {
     const canInteract = isPlayer && (isMyTurn || (currentPlayer && !currentPlayer.hasPeeked && gameState?.gamePhase === 'playing'))
@@ -715,11 +723,19 @@ const GolfGame = ({ onGameIdChange, onPlayerIdChange, onPlayerNameChange, onConn
         <div className={styles.finalRoundBackdrop} aria-hidden="true" />
       )}
 
-      {isFinalRound && !isKnocker && !knockAlertDismissed && (
+      {showKnockAlert && (
         <div
           className={styles.knockAlertOverlay}
           role="alert"
+          ref={knockAlertRef}
+          tabIndex={-1}
           onClick={() => setKnockAlertDismissed(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              setKnockAlertDismissed(true)
+            }
+          }}
         >
           <div className={styles.knockAlertContent}>
             <div className={styles.knockAlertEmoji}>✊</div>

--- a/src/apps/golf/components/__tests__/GolfGame.knock.test.tsx
+++ b/src/apps/golf/components/__tests__/GolfGame.knock.test.tsx
@@ -37,13 +37,16 @@ const makeGameState = (overrides: Partial<GameState> = {}): GameState => ({
   ...overrides
 })
 
+const playingState = () => makeGameState({ gamePhase: 'playing', knockedPlayerId: null })
+
 interface HookOverrides {
   gameState?: GameState
   playerId?: string
   isMyTurn?: boolean
+  winner?: string | null
 }
 
-const mockHook = ({ gameState = makeGameState(), playerId = 'alice', isMyTurn = true }: HookOverrides = {}) => {
+const mockHook = ({ gameState = makeGameState(), playerId = 'alice', isMyTurn = true, winner = null }: HookOverrides = {}) => {
   const currentPlayer = gameState.players.find(p => p.id === playerId) ?? null
   vi.mocked(useGolfGame).mockReturnValue({
     gameState,
@@ -56,7 +59,7 @@ const mockHook = ({ gameState = makeGameState(), playerId = 'alice', isMyTurn = 
     currentPlayer,
     isMyTurn,
     peekCountdown: null,
-    winner: null,
+    winner,
     winners: [],
     currentRoomPermalink: null,
     currentGamePermalink: null,
@@ -87,16 +90,20 @@ const mockHook = ({ gameState = makeGameState(), playerId = 'alice', isMyTurn = 
   } as unknown as ReturnType<typeof useGolfGame>)
 }
 
-const renderGame = () =>
-  render(
-    <GolfGame
-      onGameIdChange={vi.fn()}
-      onPlayerIdChange={vi.fn()}
-      onPlayerNameChange={vi.fn()}
-      onConnectionChange={vi.fn()}
-      permalinkParams={{ roomId: null, gameId: null, isValid: true }}
-    />
-  )
+const gameJsx = () => (
+  <GolfGame
+    onGameIdChange={vi.fn()}
+    onPlayerIdChange={vi.fn()}
+    onPlayerNameChange={vi.fn()}
+    onConnectionChange={vi.fn()}
+    permalinkParams={{ roomId: null, gameId: null, isValid: true }}
+  />
+)
+
+const renderGame = () => render(gameJsx())
+
+const queryBackdrop = (container: HTMLElement) =>
+  container.querySelector('[class*="finalRoundBackdrop"]')
 
 describe('GolfGame knock visibility', () => {
   beforeEach(() => {
@@ -107,21 +114,24 @@ describe('GolfGame knock visibility', () => {
     vi.useRealTimers()
   })
 
-  it('shows a full-screen alert and urgent banner to non-knockers', () => {
+  it('shows a focused full-screen alert, urgent banner, and backdrop to non-knockers', () => {
     mockHook()
-    renderGame()
+    const { container } = renderGame()
 
     expect(screen.getByRole('alert')).toHaveTextContent('bob knocked!')
     expect(screen.getByRole('alert')).toHaveTextContent('This is your last turn — make it count!')
+    expect(screen.getByRole('alert')).toHaveFocus()
     expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
     expect(screen.getByText('Your last turn — tap a pile to draw')).toBeInTheDocument()
+    expect(queryBackdrop(container)).toBeInTheDocument()
   })
 
-  it('does not show the full-screen alert to the knocker', () => {
+  it('does not show the full-screen alert or backdrop to the knocker', () => {
     mockHook({ playerId: 'bob', isMyTurn: false })
-    renderGame()
+    const { container } = renderGame()
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(queryBackdrop(container)).not.toBeInTheDocument()
     expect(screen.getByText('You knocked — final round!')).toBeInTheDocument()
   })
 
@@ -130,6 +140,16 @@ describe('GolfGame knock visibility', () => {
     renderGame()
 
     fireEvent.click(screen.getByRole('alert'))
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
+  })
+
+  it('dismisses the alert with the keyboard but keeps the banner', () => {
+    mockHook()
+    renderGame()
+
+    fireEvent.keyDown(screen.getByRole('alert'), { key: 'Escape' })
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
@@ -150,11 +170,74 @@ describe('GolfGame knock visibility', () => {
     expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
   })
 
-  it('shows no knock UI during normal play', () => {
-    mockHook({ gameState: makeGameState({ gamePhase: 'playing', knockedPlayerId: null }) })
+  it('shows the alert when a knock arrives mid-game', () => {
+    mockHook({ gameState: playingState() })
+    const view = renderGame()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    mockHook()
+    view.rerender(gameJsx())
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
+  })
+
+  it('keeps the active-player turn label through the knocked phase', () => {
+    mockHook()
     renderGame()
+
+    expect(screen.getByText('your turn')).toBeInTheDocument()
+  })
+
+  it('removes all knock UI when the game ends', () => {
+    mockHook()
+    const view = renderGame()
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('your turn')).toBeInTheDocument()
+
+    mockHook({ gameState: makeGameState({ gamePhase: 'ended' }), winner: 'bob', isMyTurn: false })
+    view.rerender(gameJsx())
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     expect(screen.queryByText(/final round/i)).not.toBeInTheDocument()
+    expect(queryBackdrop(view.container)).not.toBeInTheDocument()
+    expect(screen.queryByText('your turn')).not.toBeInTheDocument()
+  })
+
+  it('re-arms the alert for a new knock after a dismissed one', () => {
+    vi.useFakeTimers()
+    mockHook({ gameState: playingState() })
+    const view = renderGame()
+
+    // bob knocks; alice dismisses the alert
+    mockHook()
+    view.rerender(gameJsx())
+    fireEvent.click(screen.getByRole('alert'))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    // game ends, next game starts, bob knocks again
+    mockHook({ gameState: makeGameState({ gamePhase: 'ended' }), winner: 'bob', isMyTurn: false })
+    view.rerender(gameJsx())
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+    mockHook({ gameState: playingState() })
+    view.rerender(gameJsx())
+    mockHook()
+    view.rerender(gameJsx())
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('shows no knock UI during normal play', () => {
+    mockHook({ gameState: playingState() })
+    const { container } = renderGame()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByText(/final round/i)).not.toBeInTheDocument()
+    expect(queryBackdrop(container)).not.toBeInTheDocument()
+    expect(screen.getByText('Your turn — tap a pile to draw')).toBeInTheDocument()
   })
 })

--- a/src/apps/golf/components/__tests__/GolfGame.knock.test.tsx
+++ b/src/apps/golf/components/__tests__/GolfGame.knock.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import GolfGame from '../GolfGame'
+import { useGolfGame } from '@/hooks/useGolfGame'
+import type { GameState, Player } from '@/types/golf'
+
+vi.mock('@/hooks/useGolfGame', () => ({
+  useGolfGame: vi.fn()
+}))
+
+const makePlayer = (id: string): Player => ({
+  id,
+  name: id,
+  cards: [null, null, null, null],
+  score: 0,
+  revealedCards: [],
+  isReady: true,
+  hasPeeked: true,
+  clientId: `client-${id}`,
+  totalScore: 0,
+  gamesPlayed: 0,
+  gamesWon: 0,
+  isConnected: true,
+  joinedAt: '2026-01-01T00:00:00Z'
+})
+
+const makeGameState = (overrides: Partial<GameState> = {}): GameState => ({
+  id: 'GAME1',
+  players: [makePlayer('alice'), makePlayer('bob')],
+  currentPlayerIndex: 0,
+  drawPile: 40,
+  discardPile: [{ rank: '5', suit: '♠' }],
+  gamePhase: 'knocked',
+  knockedPlayerId: 'bob',
+  drawnCard: null,
+  allPlayersPeeked: true,
+  ...overrides
+})
+
+interface HookOverrides {
+  gameState?: GameState
+  playerId?: string
+  isMyTurn?: boolean
+}
+
+const mockHook = ({ gameState = makeGameState(), playerId = 'alice', isMyTurn = true }: HookOverrides = {}) => {
+  const currentPlayer = gameState.players.find(p => p.id === playerId) ?? null
+  vi.mocked(useGolfGame).mockReturnValue({
+    gameState,
+    roomState: null,
+    playerId,
+    roomCode: '',
+    isInLobby: false,
+    isInRoom: true,
+    notification: null,
+    currentPlayer,
+    isMyTurn,
+    peekCountdown: null,
+    winner: null,
+    winners: [],
+    currentRoomPermalink: null,
+    currentGamePermalink: null,
+    newGameNotifications: [],
+    createRoom: vi.fn(),
+    createGame: vi.fn(),
+    joinRoom: vi.fn(),
+    joinGame: vi.fn(),
+    startGame: vi.fn(),
+    startNewGame: vi.fn(),
+    drawCard: vi.fn(),
+    takeFromDiscard: vi.fn(),
+    discardDrawn: vi.fn(),
+    knock: vi.fn(),
+    handleCardClick: vi.fn(),
+    setRoomCode: vi.fn(),
+    leaveGame: vi.fn(),
+    leaveRoom: vi.fn(),
+    dismissNewGameNotification: vi.fn(),
+    joinNewGame: vi.fn(),
+    permalinkJoinAttempt: { isAttempting: false, error: null },
+    chatMessages: [],
+    chatAvailable: false,
+    chatReplayUpTo: null,
+    chatRejection: null,
+    sendChat: vi.fn(),
+    isConnected: true
+  } as unknown as ReturnType<typeof useGolfGame>)
+}
+
+const renderGame = () =>
+  render(
+    <GolfGame
+      onGameIdChange={vi.fn()}
+      onPlayerIdChange={vi.fn()}
+      onPlayerNameChange={vi.fn()}
+      onConnectionChange={vi.fn()}
+      permalinkParams={{ roomId: null, gameId: null, isValid: true }}
+    />
+  )
+
+describe('GolfGame knock visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows a full-screen alert and urgent banner to non-knockers', () => {
+    mockHook()
+    renderGame()
+
+    expect(screen.getByRole('alert')).toHaveTextContent('bob knocked!')
+    expect(screen.getByRole('alert')).toHaveTextContent('This is your last turn — make it count!')
+    expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
+    expect(screen.getByText('Your last turn — tap a pile to draw')).toBeInTheDocument()
+  })
+
+  it('does not show the full-screen alert to the knocker', () => {
+    mockHook({ playerId: 'bob', isMyTurn: false })
+    renderGame()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText('You knocked — final round!')).toBeInTheDocument()
+  })
+
+  it('dismisses the alert on tap but keeps the banner', () => {
+    mockHook()
+    renderGame()
+
+    fireEvent.click(screen.getByRole('alert'))
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
+  })
+
+  it('auto-dismisses the alert after 5 seconds but keeps the banner', () => {
+    vi.useFakeTimers()
+    mockHook()
+    renderGame()
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText('🚨 Final round — bob knocked! 🚨')).toBeInTheDocument()
+  })
+
+  it('shows no knock UI during normal play', () => {
+    mockHook({ gameState: makeGameState({ gamePhase: 'playing', knockedPlayerId: null }) })
+    renderGame()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByText(/final round/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #259

When someone knocks, the only signal today is a transient toast that's easy to miss. This PR makes the final round unmissable for everyone who didn't knock:

## What non-knockers see

- **Full-screen alert** the moment the knock lands: flashing red takeover with a shaking ✊, "&lt;player&gt; knocked!" and "This is your last turn — make it count!". Tap to dismiss, and it auto-dismisses after 5 seconds so it can never block the final turn.
- **Drastic color change that stays until game end**: a pulsing red vignette + red frame over the whole viewport, and an animated red "🚨 Final round — &lt;player&gt; knocked! 🚨" banner above the table. Both are keyed to the `knocked` game phase, so they persist until the game ends.
- The turn indicator now says "Your last turn — tap a pile to draw".

## What the knocker sees

A calm "You knocked — final round!" banner — they already know, so no takeover or red theme.

## Also fixed

- The active-player highlight and "your turn / their turn" labels in the header previously disappeared during the `knocked` phase (they were gated on `gamePhase === 'playing'`); they now stay on through the final round.
- All animations are disabled under `prefers-reduced-motion`.

## Testing

- New `GolfGame.knock.test.tsx` covering: non-knocker sees alert + banner, knocker gets no alert, tap-to-dismiss, 5s auto-dismiss, and no knock UI during normal play.
- Full suite: 410 tests pass; `tsc`, `eslint`, and `vite build` clean.

Works with both the v1 plugin and v2 adapter — both already populate `gamePhase: 'knocked'` and `knockedPlayerId`, which is all the UI keys off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jZcxzYVckMJewfkuVVPEA

---
_Generated by [Claude Code](https://claude.ai/code/session_011jZcxzYVckMJewfkuVVPEA)_