### PR TITLE
metrics: draw count metrics as bars, rates stay lines

### DIFF
--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -809,7 +809,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
               {containerTimeseries?.series?.some(s => s.metric_name === 'restarts') ? (
                 <ChartErrorBoundary>
                   <ResponsiveContainer width="100%" height={180}>
-                    <LineChart data={(() => {
+                    <BarChart data={(() => {
                       const restartSeries = containerTimeseries.series.filter(s => s.metric_name === 'restarts')
                       if (!containerFrame || !restartSeries.length) return []
 
@@ -845,11 +845,16 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                       {/* Not SortedTooltip: it suffixes every value with %,
                           which is right for CPU and wrong for a count. */}
                       <Tooltip />
+                      {/* Restarts are counts: each bucket is a discrete sum,
+                          not a continuous reading, so bars rather than an
+                          interpolated line. Stacked, so the bar height is
+                          total restarts in the bucket and the segments say
+                          which container. */}
                       {containerTimeseries.series.filter(s => s.metric_name === 'restarts' && s.labels?.name).map((s, i) => {
                         const colors = [COLORS.danger, COLORS.warning, COLORS.primary, COLORS.info, COLORS.success, COLORS.secondary]
-                        return <Line key={i} type="monotone" dataKey={seriesLabel(s.labels!.name)} stroke={colors[i % colors.length]} strokeWidth={2} dot={false} />
+                        return <Bar key={i} dataKey={seriesLabel(s.labels!.name)} fill={colors[i % colors.length]} stackId="restarts" />
                       })}
-                    </LineChart>
+                    </BarChart>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (

--- a/src/apps/metrics-systems/components/ServiceDashboard.tsx
+++ b/src/apps/metrics-systems/components/ServiceDashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { LineChart, Line, AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
 import styles from './MetricsDashboard.module.css'
 import ContainerHealthStrip from './ContainerHealth'
@@ -63,6 +63,7 @@ interface TrendEntry {
   title: string
   series: TimeSeries | undefined
   unit: string
+  bar: boolean
 }
 
 // Collapses a service's custom series into what Trends actually renders. A
@@ -98,12 +99,15 @@ const groupTrends = (series: TimeSeries[], view: MetricView): TrendEntry[] => {
           // form cue itself, the same "/s" a unitless scalar tile gets from
           // UnitFor in the rate view.
           unit: view === 'count' ? '' : '/s',
+          // A count is a per-bucket sum, not a continuous quantity — bars,
+          // not an interpolated line. The rate form stays a line.
+          bar: view === 'count',
         })
         continue
       }
     }
     consumed.add(s.metric_name)
-    entries.push({ key: s.metric_name, title: prettyLabel(s.metric_name), series: s, unit: '' })
+    entries.push({ key: s.metric_name, title: prettyLabel(s.metric_name), series: s, unit: '', bar: false })
   }
   return entries
 }
@@ -149,6 +153,7 @@ const SeriesChart = ({
   color,
   unit,
   area = false,
+  bar = false,
   scale = (value: number) => value,
   emptyMessage,
 }: {
@@ -158,6 +163,7 @@ const SeriesChart = ({
   color: string
   unit: string
   area?: boolean
+  bar?: boolean
   scale?: (value: number) => number
   emptyMessage?: string
 }) => {
@@ -186,7 +192,7 @@ const SeriesChart = ({
       value: scale(Math.max(0, v.value || 0)),
     }))
   }
-  const ChartComponent = area ? AreaChart : LineChart
+  const ChartComponent = bar ? BarChart : area ? AreaChart : LineChart
 
   return (
     <div className={styles.compactChart}>
@@ -201,7 +207,9 @@ const SeriesChart = ({
               contentStyle={{ backgroundColor: 'rgba(13, 17, 32, 0.9)', border: '1px solid rgba(255, 255, 255, 0.3)', borderRadius: '8px', fontSize: '12px' }}
               formatter={(value) => [`${formatValue(Number(value))}${unit ? ` ${unit}` : ''}`, title]}
             />
-            {area ? (
+            {bar ? (
+              <Bar dataKey="value" fill={color} radius={[2, 2, 0, 0]} />
+            ) : area ? (
               <Area type="monotone" dataKey="value" stroke={color} fill={`${color}44`} strokeWidth={2} />
             ) : (
               <Line type="monotone" dataKey="value" stroke={color} strokeWidth={2} dot={false} />
@@ -407,6 +415,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
               frame={frame}
               color={COLORS.primary}
               unit={requestPick.form === 'count' ? 'requests' : 'req/s'}
+              bar={requestPick.form === 'count'}
               emptyMessage={emptyMessage}
             />
             <SeriesChart
@@ -415,6 +424,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
               frame={frame}
               color={COLORS.danger}
               unit={errorPick.form === 'count' ? 'errors' : '%'}
+              bar={errorPick.form === 'count'}
               emptyMessage={emptyMessage}
             />
             <SeriesChart title="P95 Latency" series={findSeries('p95_duration_us')} frame={frame} color={COLORS.warning} unit="ms" scale={(v) => v / 1000} area emptyMessage={emptyMessage} />
@@ -457,6 +467,7 @@ const ServiceDashboard = ({ service, onConnectionStateChange }: ServiceDashboard
                   frame={frame}
                   color={[COLORS.primary, COLORS.info, COLORS.success, COLORS.warning][index % 4]}
                   unit={entry.unit}
+                  bar={entry.bar}
                   emptyMessage={emptyMessage}
                 />
               ))}

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -360,9 +360,10 @@ describe('MetricsDashboard (host view)', () => {
       await settle()
 
       expect(screen.getByText('Container Restarts')).toBeTruthy()
-      // The only series in this fixture is restarts, so any <Line> at all comes
-      // from the new chart rather than from CPU or memory.
-      const keys = screen.getAllByTestId('line').map((el) => el.getAttribute('data-key'))
+      // Restarts are counts, so they chart as bars; the per-container bar
+      // charts key on fixed names (cpu, rx, …), so a <Bar> keyed on the
+      // container's own label can only come from the restarts chart.
+      const keys = screen.getAllByTestId('bar').map((el) => el.getAttribute('data-key'))
       expect(keys).toContain('golf_hub')
     })
 

--- a/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/ServiceDashboard.test.tsx
@@ -14,6 +14,10 @@ vi.mock('recharts', () => ({
     <div data-testid="area-chart" data-row-count={data?.length ?? 0}>{children}</div>
   ),
   Area: () => <div data-testid="area" />,
+  BarChart: ({ children, data }: { children: React.ReactNode; data?: unknown[] }) => (
+    <div data-testid="bar-chart" data-row-count={data?.length ?? 0}>{children}</div>
+  ),
+  Bar: () => <div data-testid="bar" />,
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
   CartesianGrid: () => <div data-testid="cartesian-grid" />,
@@ -545,6 +549,28 @@ describe('ServiceDashboard', () => {
 
     expect(screen.getByText('Request Rate')).toBeTruthy()
     expect(screen.queryByText('Requests')).toBeNull()
+  })
+
+  it('draws counts as bars and rates as lines', async () => {
+    render(<ServiceDashboard service="golf_hub" onConnectionStateChange={vi.fn()} />)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    // A count is a per-bucket sum: each bucket stands alone and zero means
+    // nothing happened, so bars. A rate is a sampled derivative, so a line.
+    const requestsChart = screen.getByText('Requests').parentElement as HTMLElement
+    expect(within(requestsChart).getByTestId('bar-chart')).toBeTruthy()
+    expect(within(requestsChart).queryByTestId('line-chart')).toBeNull()
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Counter view'), { target: { value: 'rate' } })
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    const rateChart = screen.getByText('Request Rate').parentElement as HTMLElement
+    expect(within(rateChart).getByTestId('line-chart')).toBeTruthy()
+    expect(within(rateChart).queryByTestId('bar-chart')).toBeNull()
   })
 
   it('switches the Error Rate chart between error_count and error_rate_percent', async () => {


### PR DESCRIPTION
Counter charts on the service dashboard (Serving requests/errors, paired Trends series) now render as bar charts when the count/rate toggle is on count, since each bucket is a discrete sum rather than a continuous reading. Rate views keep their lines, and the container restarts chart becomes stacked bars so bar height reads as total restarts per bucket.

Tested with `npm run lint`, `npm run build`, and `vitest run` (406 passing).