### PR TITLE
Animate host dashboard loading states with a ghost-chart skeleton

### DIFF
--- a/src/apps/metrics-systems/components/ChartSkeleton.tsx
+++ b/src/apps/metrics-systems/components/ChartSkeleton.tsx
@@ -1,0 +1,25 @@
+import styles from './MetricsDashboard.module.css'
+
+// Ghost chart shown while a widget's first fetch is in flight. Bar heights are
+// fixed, not random: the placeholder is furniture, not data, so every widget
+// should idle identically on every visit instead of inviting a read.
+const BAR_HEIGHTS = [45, 70, 55, 80, 60, 88, 65, 50]
+
+const ChartSkeleton = () => (
+  <div className={styles.chartSkeleton} data-testid="chart-skeleton">
+    {BAR_HEIGHTS.map((height, i) => (
+      <div
+        key={i}
+        className={styles.skeletonBar}
+        // Negative delays start each bar mid-cycle, so the wave is already
+        // rolling on first paint instead of fading in from a dead stop.
+        style={{ height: `${height}%`, animationDelay: `${(i * -0.18).toFixed(2)}s` }}
+      />
+    ))}
+    {/* The bars are decorative; the words carry the state for screen readers
+        and text queries. */}
+    <span className={styles.srOnly}>Loading…</span>
+  </div>
+)
+
+export default ChartSkeleton

--- a/src/apps/metrics-systems/components/MetricsDashboard.module.css
+++ b/src/apps/metrics-systems/components/MetricsDashboard.module.css
@@ -450,6 +450,75 @@
   text-align: center;
 }
 
+/* Loading skeleton — a ghost chart standing where the real one will render.
+   Same 180px as .noData and the charts themselves, so widgets don't reflow
+   when data lands. The motion is carried by opacity alone: bars that grow or
+   shimmer sideways read as data arriving, which is a claim the page can't
+   make yet. */
+.chartSkeleton {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 10px;
+  height: 180px;
+  padding: 24px 12px 12px;
+  box-sizing: border-box;
+}
+
+/* Bars flex to the panel rather than sitting at a fixed width: the ghost has
+   to span the full-width single-chart panels (Container Restarts) as well as
+   the four-column ones, or it reads as a lost widget instead of a chart
+   placeholder. */
+.skeletonBar {
+  flex: 1 1 0;
+  max-width: 9%;
+  border-radius: 4px 4px 2px 2px;
+  background: rgba(102, 182, 255, 0.5);
+  animation: skeletonPulse 1.8s ease-in-out infinite;
+}
+
+/* Placeholder value inside a stat tile while the first fetch is in flight.
+   The labels are fixed copy, so the tiles render at their final size with
+   only the numbers idling — the row used to pop in wholesale when data
+   landed, shoving everything below it down. */
+.skeletonValue {
+  display: inline-block;
+  width: 3.5em;
+  height: 1em;
+  border-radius: 4px;
+  background: rgba(102, 182, 255, 0.5);
+  animation: skeletonPulse 1.8s ease-in-out infinite;
+}
+
+@keyframes skeletonPulse {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 0.85; }
+}
+
+/* The static fallback sits at the top of the pulse range, not its middle:
+   with no motion to catch the eye, the bars are the whole loading signal and
+   have to clear the card background on their own. */
+@media (prefers-reduced-motion: reduce) {
+  .skeletonBar,
+  .skeletonValue {
+    animation: none;
+    opacity: 0.7;
+  }
+}
+
+/* Visually hidden but still present for screen readers and text queries. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .error {
   background: rgba(255, 102, 102, 0.1);
   border: 1px solid rgba(255, 102, 102, 0.3);

--- a/src/apps/metrics-systems/components/MetricsDashboard.tsx
+++ b/src/apps/metrics-systems/components/MetricsDashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts'
 import ChartErrorBoundary from './ChartErrorBoundary'
+import ChartSkeleton from './ChartSkeleton'
 import styles from './MetricsDashboard.module.css'
 import {
   METRICS_API_URL,
@@ -121,9 +122,9 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   const [containerTimeseries, setContainerTimeseries] = useState<TimeSeriesResponse | null>(null)
   const [timeRange, setTimeRange] = useState<'30m' | '1d' | '7d'>('1d')
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
-  // True until the first fetch settles either way. Empty panels say
-  // "Loading…" during it — flashing "No data available" at someone for the
-  // second before data lands claims a gap that doesn't exist.
+  // True until the first fetch settles either way. Empty panels show the
+  // loading skeleton during it — flashing "No data available" at someone for
+  // the second before data lands claims a gap that doesn't exist.
   const [loading, setLoading] = useState(true)
 
   // Charts get their container names from timeseries labels, which carry only
@@ -183,7 +184,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
   const systemFrame = seriesWindow(systemTimeseries)
   const containerFrame = seriesWindow(containerTimeseries)
 
-  const emptyMessage = loading ? 'Loading…' : 'No data available'
+  const emptyState = loading ? <ChartSkeleton /> : <NoDataMessage />
 
   const getCpuTimeseriesData = () => {
     const cpuSeries = systemTimeseries?.series?.find(s => s.metric_name === 'cpu_utilization')
@@ -310,6 +311,22 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
             unlabeled cluster. */}
         <div className={styles.section}>
           <h2 className={styles.sectionTitle}>System Resources</h2>
+          {/* While the first fetch is in flight the tiles render with
+              placeholder values instead of not at all — the labels are fixed
+              copy, so the row can hold its final size rather than popping in
+              wholesale when data lands and shoving the charts down. */}
+          {!systemMetrics && loading && (
+            <div className={styles.overviewCards}>
+              {['CPU', 'Memory', 'Disk', 'Network'].map((label) => (
+                <div key={label} className={styles.miniCard}>
+                  <div className={styles.miniLabel}>{label}</div>
+                  <div className={styles.miniValue}>
+                    <span className={styles.skeletonValue} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           {systemMetrics && (
             <div className={styles.overviewCards}>
               <div className={styles.miniCard}>
@@ -366,7 +383,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -389,7 +406,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -412,7 +429,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -441,7 +458,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
           </div>
@@ -471,7 +488,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -498,7 +515,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -522,7 +539,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
           </div>
@@ -587,7 +604,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -613,7 +630,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -672,7 +689,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
           </div>
@@ -704,7 +721,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -732,7 +749,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -791,7 +808,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
           </div>
@@ -858,7 +875,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={loading ? 'Loading…' : 'No restart data in this window'} />
+                loading ? <ChartSkeleton /> : <NoDataMessage message="No restart data in this window" />
               )}
             </div>
           </div>
@@ -890,7 +907,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
 
@@ -916,7 +933,7 @@ const MetricsDashboard = ({ onConnectionStateChange }: MetricsDashboardProps) =>
                   </ResponsiveContainer>
                 </ChartErrorBoundary>
               ) : (
-                <NoDataMessage message={emptyMessage} />
+                emptyState
               )}
             </div>
           </div>

--- a/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
+++ b/src/apps/metrics-systems/components/__tests__/MetricsDashboard.test.tsx
@@ -141,14 +141,67 @@ describe('MetricsDashboard (host view)', () => {
     expect(urls.some((url) => url.endsWith('/host/timeseries/7d'))).toBe(true)
   })
 
-  it('says loading, not "no data", before the first fetch resolves', () => {
+  it('shows the loading skeleton, not "no data", before the first fetch resolves', () => {
     // A pending fetch is a promise of an answer, not an answer. Every chart
     // used to flash "No data available" for the second before data landed.
+    // The skeleton's visible part is decorative bars, so the accessible
+    // "Loading…" text must ride along with it.
     mockFetch.mockImplementation(() => new Promise(() => {}))
     render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
 
+    expect(screen.getAllByTestId('chart-skeleton').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Loading…').length).toBeGreaterThan(0)
     expect(screen.queryByText('No data available')).toBeNull()
+    // The restarts panel spells its own loading ternary (it has a custom
+    // settled message), so the flash-guard needs pinning there separately.
+    expect(screen.queryByText('No restart data in this window')).toBeNull()
+    // The System Resources tiles hold their row open with placeholder values
+    // instead of popping in wholesale when data lands.
+    expect(screen.getByText('CPU')).toBeTruthy()
+    expect(screen.getByText('Network')).toBeTruthy()
+  })
+
+  it('drops the skeleton once the first fetch settles, even a failed one', async () => {
+    // The skeleton claims an answer is coming. After the fetch settles empty,
+    // that claim is false — an infinitely shimmering placeholder over a dead
+    // API reads as "still loading" forever.
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, text: () => Promise.resolve('') }))
+    render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(screen.queryAllByTestId('chart-skeleton').length).toBe(0)
+    expect(screen.queryByText('Loading…')).toBeNull()
+    expect(screen.getAllByText('No data available').length).toBeGreaterThan(0)
+    expect(screen.getByText('No restart data in this window')).toBeTruthy()
+    // The placeholder tiles are a loading treatment, not a fallback — with the
+    // API down they'd be a permanent row of shimmering nothing.
+    expect(screen.queryByText('CPU')).toBeNull()
+  })
+
+  it('keeps the skeleton a first-load treatment — a range change refetch does not resurrect it', async () => {
+    // Deliberate: on a range change the panels keep their settled state (data
+    // or "No data available") until the new response lands. Re-arming the
+    // skeleton here would also re-arm it on every 30s poll, turning empty
+    // panels into an endlessly re-flashing placeholder.
+    const { container } = render(<MetricsDashboard onConnectionStateChange={vi.fn()} />)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+    expect(screen.getAllByText('No data available').length).toBeGreaterThan(0)
+
+    mockFetch.mockImplementation(() => new Promise(() => {}))
+    const select = container.querySelector('select')!
+    fireEvent.change(select, { target: { value: '7d' } })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+
+    expect(screen.queryAllByTestId('chart-skeleton').length).toBe(0)
+    expect(screen.getAllByText('No data available').length).toBeGreaterThan(0)
   })
 
   it('stays up with empty sections when the API is down', async () => {


### PR DESCRIPTION
## What

Replaces the static "Loading…" text in the host metrics page's empty widgets with a subtle animated loading state:

- Each empty chart panel idles as a **ghost chart** (`ChartSkeleton`): eight bars in the dashboard's blue, pulsing opacity in a slow staggered wave (1.8s cycle, negative delays so the wave is already rolling on first paint). Bars flex to the panel width so the ghost spans the full-width Container Restarts panel as well as the four-column sections.
- The **System Resources tiles** now render during loading with pulsing placeholder values — the labels are fixed copy, so the row holds its final size instead of popping in wholesale when data lands.
- "Loading…" stays in the DOM as visually hidden text, so screen readers hear the same state as before.
- `prefers-reduced-motion` gets static bars at the top of the pulse range — with no motion they're the whole signal, so they sit brighter.

## Deliberate choices

- **First-load-only.** Range changes and the 30s poll keep panels on their settled state until the new response lands; re-arming the skeleton would re-flash every empty panel on every poll. Pinned by a test.
- The Containers card section still renders nothing while loading: its card count is unknown before data, so a placeholder row would claim a shape the page can't know.
- The service and containers tabs keep their static loading text — same treatment there is a natural follow-up via the shared CSS module.

## Review panel

The four-lens read-only panel ran on the diff (React correctness, CSS/UX/a11y, altitude/integration, tests). It caught two real defects in the first cut, both fixed: bars too faint to perceive (effective alpha as low as 0.075, worst under reduced motion) and a fixed-width bar cluster stranded in the full-width restarts panel. Its two unpinned-behavior findings each got a test.

## Testing

- Skeleton (with accessible text) while the first fetch is in flight; no "No data available" flash, including the restarts panel's separately-spelled branch.
- Skeleton drops once the first fetch settles — even a failed one — and the placeholder tiles drop with it.
- Range-change refetch does not resurrect the skeleton.
- Both new negative pins were proven to bite by hand-mutating the behavior and watching the test go red before reverting.
- `npm run typecheck`, `npm run lint`, `npm run test:run` (418 tests), and `npm run build` all pass; the timing-sensitive test re-run three times clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmxbtwU66uVfSm2MSm8mqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmxbtwU66uVfSm2MSm8mqa)_