### PR TITLE
nav: add Elsewhere dropdown linking off-domain apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ npm run deploy
 | `/resilience` | Distributed-systems game |
 | `/groups`, `/sets`, `/top` | Math learning modules (permutation groups, sets, Topology Quest) |
 
-The nav's **Elsewhere** menu links to apps hosted off muchq.com (r3dr.net,
-snowbonk.com, 1d4.net, hovercrap.com, 3xe.org). Those are external links, not
-routes — their code lives in their own repos, not here.
+The nav's **Elsewhere** menu links to apps hosted off muchq.com (see the
+`elsewhere` group in `src/shared/components/Navigation.tsx` for the current
+list). Those are external links, not routes — their code lives in their own
+repos, not here.
 
 ### Golf v1/v2
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ npm run deploy
 | `/resilience` | Distributed-systems game |
 | `/groups`, `/sets`, `/top` | Math learning modules (permutation groups, sets, Topology Quest) |
 
+The nav's **Elsewhere** menu links to apps hosted off muchq.com (r3dr.net,
+snowbonk.com, 1d4.net, hovercrap.com, 3xe.org). Those are external links, not
+routes — their code lives in their own repos, not here.
+
 ### Golf v1/v2
 
 Golf speaks two wires. The default v1 protocol is documented in [GOLF.md](GOLF.md); the v2

--- a/src/shared/components/Navigation.module.css
+++ b/src/shared/components/Navigation.module.css
@@ -243,7 +243,8 @@
   .navItem.expanded .dropdown {
     opacity: 1;
     visibility: visible;
-    max-height: 500px;
+    /* Tall enough for the largest group (11 described items) with headroom for text zoom */
+    max-height: 1200px;
     margin-top: 8px;
     padding: 8px 0;
   }

--- a/src/shared/components/Navigation.module.css
+++ b/src/shared/components/Navigation.module.css
@@ -80,6 +80,8 @@
   transform: translateY(-10px);
   transition: all 0.3s ease;
   min-width: 150px;
+  width: max-content;
+  max-width: 280px;
   padding: 8px 0;
 }
 
@@ -91,7 +93,8 @@
   line-height: 1;
 }
 
-.navItem:hover .dropdown {
+.navItem:hover .dropdown,
+.navItem:focus-within .dropdown {
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
@@ -116,68 +119,28 @@
   font-weight: 500;
 }
 
-.dropdownItem span {
-  display: block;
-  cursor: default;
-  font-weight: 500;
-  position: relative;
+.externalMark {
+  font-size: 11px;
+  color: #767676; /* darkest gray that clears WCAG AA 4.5:1 on white */
 }
 
-.dropdownItem span::after {
-  content: '▸';
+.linkDescription {
+  display: block;
+  font-size: 12px;
+  color: #767676;
+  margin-top: 1px;
+}
+
+.srOnly {
   position: absolute;
-  right: 0;
-  opacity: 0.5;
-  transition: transform 0.2s ease;
-}
-
-.dropdownItem:hover span::after {
-  transform: translateX(2px);
-  opacity: 0.8;
-}
-
-.submenu {
-  display: none;
-  margin-top: 8px;
-  padding: 4px 0;
-  background: rgba(103, 126, 234, 0.03);
-  border-radius: 6px;
-  animation: slideIn 0.2s ease;
-}
-
-@keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateX(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.dropdownItem:hover .submenu {
-  display: block;
-}
-
-.submenuItem {
-  display: block;
-  padding: 10px 16px;
-  margin: 2px 8px;
-  color: #555;
-  text-decoration: none;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  border-left: 3px solid transparent;
-  border-radius: 4px;
-}
-
-.submenuItem:hover {
-  background: linear-gradient(90deg, rgba(103, 126, 234, 0.08) 0%, rgba(103, 126, 234, 0.02) 100%);
-  border-left-color: #667eea;
-  color: #333;
-  transform: translateX(2px);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .mobileMenuToggle {
@@ -264,6 +227,9 @@
     overflow: hidden;
     transition: all 0.3s ease;
     padding: 0;
+    /* Reset the desktop max-content sizing so the accordion panel spans the full row */
+    width: auto;
+    max-width: none;
   }
 
   /* Disable hover on mobile to prevent interference with touch events */

--- a/src/shared/components/Navigation.tsx
+++ b/src/shared/components/Navigation.tsx
@@ -57,6 +57,12 @@ const MENU: MenuGroup[] = [
       { label: '1d4', to: 'https://1d4.net', external: true, description: 'Chess game indexer' },
       { label: 'HoverCrap', to: 'https://hovercrap.com', external: true, description: 'ASCII hovercraft' },
       { label: '3xe', to: 'https://3xe.org', external: true, description: 'Madrid-style cheesecake' },
+      { label: 'BitFear', to: 'https://bitfear.net', external: true, description: 'Text-to-binary converter' },
+      { label: 'Smallcat', to: 'https://smallcat.dog', external: true, description: 'Pong' },
+      { label: '2n-1', to: 'https://2n-1.org', external: true, description: 'Odd-number mathematics' },
+      { label: 'tty1', to: 'https://tty1.uk', external: true, description: 'Web terminal' },
+      { label: '里に春が来ました', to: 'https://sato-ni-haru-ga-kimashita.uk', external: true, description: 'Japanese sentence breakdown' },
+      { label: 'p2bx', to: 'https://p2bx.uk', external: true, description: 'Stone–Čech compactification' },
     ],
   },
   {

--- a/src/shared/components/Navigation.tsx
+++ b/src/shared/components/Navigation.tsx
@@ -17,6 +17,8 @@ interface MenuLink {
   label: string
   to: string
   external?: boolean
+  /** One-line subtitle shown under the label, for links whose names don't explain themselves */
+  description?: string
 }
 
 interface MenuGroup {
@@ -44,6 +46,17 @@ const MENU: MenuGroup[] = [
       { label: 'Golf', to: '/golf' },
       { label: 'Party', to: '/party' },
       { label: 'Resilience', to: '/resilience' },
+    ],
+  },
+  {
+    name: 'elsewhere',
+    label: 'Elsewhere',
+    links: [
+      { label: 'r3dr', to: 'https://r3dr.net', external: true, description: 'URL shortener' },
+      { label: 'Snowbonk', to: 'https://snowbonk.com', external: true, description: 'N-body simulation viewer' },
+      { label: '1d4', to: 'https://1d4.net', external: true, description: 'Chess game indexer' },
+      { label: 'HoverCrap', to: 'https://hovercrap.com', external: true, description: 'ASCII hovercraft' },
+      { label: '3xe', to: 'https://3xe.org', external: true, description: 'Madrid-style cheesecake' },
     ],
   },
   {
@@ -111,10 +124,27 @@ const Navigation = ({ className, appName, context, floating }: NavigationProps) 
                 <span className={styles.accordionIcon}>›</span>
               </a>
               <div className={styles.dropdown}>
-                {group.links.map(link =>
-                  link.external ? (
-                    <a key={link.label} href={link.to} className={styles.dropdownItem}>
+                {group.links.map(link => {
+                  const children = (
+                    <>
                       {link.label}
+                      {link.external && (
+                        <>
+                          {/* U+FE0E pins text presentation: a bare ↗ renders as a color emoji on some platforms */}
+                          <span className={styles.externalMark} aria-hidden="true">
+                            {' ↗︎'}
+                          </span>
+                          <span className={styles.srOnly}> (external site)</span>
+                        </>
+                      )}
+                      {link.description && (
+                        <span className={styles.linkDescription}>{link.description}</span>
+                      )}
+                    </>
+                  )
+                  return link.external ? (
+                    <a key={link.label} href={link.to} className={styles.dropdownItem}>
+                      {children}
                     </a>
                   ) : (
                     <Link
@@ -122,10 +152,10 @@ const Navigation = ({ className, appName, context, floating }: NavigationProps) 
                       to={link.to}
                       className={`${styles.dropdownItem} ${isCurrentRoute(link.to) ? styles.currentItem : ''}`}
                     >
-                      {link.label}
+                      {children}
                     </Link>
                   )
-                )}
+                })}
               </div>
             </li>
           ))}

--- a/src/shared/components/__tests__/Navigation.test.tsx
+++ b/src/shared/components/__tests__/Navigation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen as testingScreen } from '@testing-library/react'
+import { render, screen as testingScreen, within } from '@testing-library/react'
 import { BrowserRouter, MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import Navigation from '../Navigation'
@@ -22,8 +22,58 @@ describe('Navigation', () => {
     renderWithRouter(<Navigation />)
     expect(testingScreen.getByText('Projects')).toBeDefined()
     expect(testingScreen.getByText('Games')).toBeDefined()
+    expect(testingScreen.getByText('Elsewhere')).toBeDefined()
     expect(testingScreen.getByText('Code')).toBeDefined()
     expect(testingScreen.getByText('Metrics')).toBeDefined()
+  })
+
+  // The accessible-name regexes are anchored and include "(external site)" on
+  // purpose: they pin that the srOnly text is part of the name AND that the
+  // aria-hidden ↗ is excluded from it (its presence would break the anchor).
+  it('links each Elsewhere app to its URL, with its description inside the link', () => {
+    renderWithRouter(<Navigation />)
+    const groupEl = testingScreen.getByText('Elsewhere').closest('li')
+    if (!groupEl) throw new Error('Elsewhere nav group not found')
+    const group = within(groupEl)
+    const expected: Array<[RegExp, string, string]> = [
+      [/^r3dr\s?\(external site\)/, 'https://r3dr.net', 'URL shortener'],
+      [/^Snowbonk\s?\(external site\)/, 'https://snowbonk.com', 'N-body simulation viewer'],
+      [/^1d4\s?\(external site\)/, 'https://1d4.net', 'Chess game indexer'],
+      [/^HoverCrap\s?\(external site\)/, 'https://hovercrap.com', 'ASCII hovercraft'],
+      [/^3xe\s?\(external site\)/, 'https://3xe.org', 'Madrid-style cheesecake'],
+    ]
+    for (const [name, href, description] of expected) {
+      const link = group.getByRole('link', { name })
+      expect(link.getAttribute('href')).toBe(href)
+      expect(within(link).getByText(description)).toBeDefined()
+    }
+  })
+
+  it('marks external links with a visible ↗ kept out of the accessible name', () => {
+    renderWithRouter(<Navigation />)
+    const external = testingScreen.getByRole('link', {
+      name: /^Snowbonk\s?\(external site\)/,
+    })
+    expect(external.textContent).toContain('↗')
+  })
+
+  it('visually hides the screen-reader-only external marker text', () => {
+    renderWithRouter(<Navigation />)
+    const external = testingScreen.getByRole('link', {
+      name: /^Snowbonk\s?\(external site\)/,
+    })
+    const srSpan = Array.from(external.querySelectorAll('span')).find(s =>
+      s.textContent?.includes('(external site)')
+    )
+    expect(srSpan?.className).toContain('srOnly')
+  })
+
+  it('leaves internal links unmarked', () => {
+    renderWithRouter(<Navigation />)
+    const internal = testingScreen.getByRole('link', { name: 'Golf' })
+    expect(internal.getAttribute('href')).toBe('/golf')
+    expect(internal.textContent).not.toContain('↗')
+    expect(internal.textContent).not.toContain('(external site)')
   })
 
   it('renders the app name in the brand link', () => {

--- a/src/shared/components/__tests__/Navigation.test.tsx
+++ b/src/shared/components/__tests__/Navigation.test.tsx
@@ -41,6 +41,12 @@ describe('Navigation', () => {
       [/^1d4\s?\(external site\)/, 'https://1d4.net', 'Chess game indexer'],
       [/^HoverCrap\s?\(external site\)/, 'https://hovercrap.com', 'ASCII hovercraft'],
       [/^3xe\s?\(external site\)/, 'https://3xe.org', 'Madrid-style cheesecake'],
+      [/^BitFear\s?\(external site\)/, 'https://bitfear.net', 'Text-to-binary converter'],
+      [/^Smallcat\s?\(external site\)/, 'https://smallcat.dog', 'Pong'],
+      [/^2n-1\s?\(external site\)/, 'https://2n-1.org', 'Odd-number mathematics'],
+      [/^tty1\s?\(external site\)/, 'https://tty1.uk', 'Web terminal'],
+      [/^里に春が来ました\s?\(external site\)/, 'https://sato-ni-haru-ga-kimashita.uk', 'Japanese sentence breakdown'],
+      [/^p2bx\s?\(external site\)/, 'https://p2bx.uk', 'Stone–Čech compactification'],
     ]
     for (const [name, href, description] of expected) {
       const link = group.getByRole('link', { name })


### PR DESCRIPTION
## What

Adds a fourth nav group, **Elsewhere**, between Games and Code, linking the apps hosted off muchq.com. Each entry carries a one-line muted description (names like "Snowbonk" and "p2bx" don't explain themselves), and every external link site-wide — including the existing Code group — now shows an `aria-hidden` ↗ plus visually-hidden "(external site)" text in its accessible name.

Current roster: r3dr, Snowbonk, 1d4, HoverCrap, 3xe, BitFear, Smallcat, 2n-1, tty1, 里に春が来ました, p2bx. All eleven were verified live, and descriptions come from what each site actually serves. Deliberately excluded until they're ready: eggsample.net and colorsandboxes.com (owner wants to fix them up first) and ast.lol (not yet deployed).

## Supporting changes

- **Keyboard access:** dropdowns now also open on `:focus-within`; hover was previously the only path, and these links exist nowhere else on the site.
- **Dead CSS removed:** `.submenu` / `.submenuItem` / `.dropdownItem span` were unreferenced, and the `span` element selector would have mangled the new markup — the deletion is load-bearing, not tidying.
- **Contrast:** the new muted text uses `#767676` (4.5:1 on white, WCAG AA); `↗` is pinned to text presentation with U+FE0E so it doesn't render as a color emoji on iOS/Android font stacks.
- **Mobile accordion:** desktop `width: max-content` sizing is explicitly reset to full-width in the mobile block, and the reveal `max-height` is raised to 1200px for the 11-item group.
- README points at the `elsewhere` group in `Navigation.tsx` instead of enumerating domains, so there's one list to keep accurate.

## Review and verification

The working agreement's four-lens review panel ran on the first commit (React correctness, CSS/UX/a11y, altitude, tests/CI); all surviving findings were fixed and are test-pinned. The second commit (six more menu entries) is data rows on the reviewed pattern and did not get a fresh panel.

Tests assert accessible names (which pins both the sr-only text and the aria-hidden exclusion), group membership via `within()`, and label→description pairing. Each negative pin was proven to bite by hand-mutation (5 behavior mutations, each red). Gates: typecheck, lint (zero warnings), 422/422 tests, production build. Verified in Chromium: desktop hover, keyboard tabbing (focus ring reaches all five-then-eleven links), and the mobile accordion at 390px.

Follow-up worth filing: `.srOnly` is now the third identical visually-hidden CSS block in the repo (RoomChat, MetricsDashboard) — extract to a shared home instead of adding a fourth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwyugb5AHuiqf93vgUCMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUwyugb5AHuiqf93vgUCMc)_